### PR TITLE
ApiHttp: Handle 401 Error (Unauthorized)

### DIFF
--- a/api/src/main/scala/com/lbs/api/http/package.scala
+++ b/api/src/main/scala/com/lbs/api/http/package.scala
@@ -74,6 +74,8 @@ package object http extends StrictLogging {
       code match {
         case HttpURLConnection.HTTP_MOVED_TEMP if httpResponse.header("Location").exists(_.contains("/LogOn")) =>
           Some(new SessionExpiredException)
+        case HttpURLConnection.HTTP_UNAUTHORIZED if lowercasedBody.contains("session has expired") =>
+          Some(new SessionExpiredException)
         case HttpURLConnection.HTTP_CONFLICT
             if lowercasedBody
               .contains("nieprawidłowy login lub hasło") || lowercasedBody.contains("invalid login or password") =>


### PR DESCRIPTION
We are getting simple response `{"Message":"The session has expired. Log in again."}` from (old) Events API.