### PR TITLE
Add multi-facility monitoring and quicker date selection

### DIFF
--- a/server/src/main/resources/db/changelog/08-add-monitoring-clinic-list-and-exclusions.yml
+++ b/server/src/main/resources/db/changelog/08-add-monitoring-clinic-list-and-exclusions.yml
@@ -1,0 +1,26 @@
+databaseChangeLog:
+- changeSet:
+    id: 1780400000000-1
+    author: codex
+    preConditions:
+      onFail: MARK_RAN
+      not:
+        columnExists:
+          tableName: monitoring
+          columnName: clinic_ids
+    changes:
+    - addColumn:
+        tableName: monitoring
+        columns:
+        - column:
+            name: clinic_ids
+            type: VARCHAR(1024)
+        - column:
+            name: clinic_names
+            type: VARCHAR(2048)
+        - column:
+            name: excluded_weekdays
+            type: VARCHAR(32)
+        - column:
+            name: excluded_dates
+            type: VARCHAR(2048)

--- a/server/src/main/resources/db/changelog/08-add-monitoring-clinic-list-and-exclusions.yml
+++ b/server/src/main/resources/db/changelog/08-add-monitoring-clinic-list-and-exclusions.yml
@@ -1,7 +1,7 @@
 databaseChangeLog:
 - changeSet:
     id: 1780400000000-1
-    author: codex
+    author: community
     preConditions:
       onFail: MARK_RAN
       not:

--- a/server/src/main/resources/db/changelog/09-add-monitoring-clinic-selection.yml
+++ b/server/src/main/resources/db/changelog/09-add-monitoring-clinic-selection.yml
@@ -1,0 +1,17 @@
+databaseChangeLog:
+- changeSet:
+    id: 1780500000000-1
+    author: community
+    preConditions:
+      onFail: MARK_RAN
+      not:
+        columnExists:
+          tableName: monitoring
+          columnName: clinic_selection
+    changes:
+    - addColumn:
+        tableName: monitoring
+        columns:
+        - column:
+            name: clinic_selection
+            type: VARCHAR(4096)

--- a/server/src/main/resources/db/changelog/10-ensure-monitoring-clinic-list-and-exclusions.yml
+++ b/server/src/main/resources/db/changelog/10-ensure-monitoring-clinic-list-and-exclusions.yml
@@ -1,0 +1,51 @@
+databaseChangeLog:
+- changeSet:
+    id: 1780600000000-1
+    author: community
+    preConditions:
+      onFail: MARK_RAN
+      not:
+        columnExists:
+          tableName: monitoring
+          columnName: clinic_names
+    changes:
+    - addColumn:
+        tableName: monitoring
+        columns:
+        - column:
+            name: clinic_names
+            type: VARCHAR(2048)
+
+- changeSet:
+    id: 1780600000000-2
+    author: community
+    preConditions:
+      onFail: MARK_RAN
+      not:
+        columnExists:
+          tableName: monitoring
+          columnName: excluded_weekdays
+    changes:
+    - addColumn:
+        tableName: monitoring
+        columns:
+        - column:
+            name: excluded_weekdays
+            type: VARCHAR(32)
+
+- changeSet:
+    id: 1780600000000-3
+    author: community
+    preConditions:
+      onFail: MARK_RAN
+      not:
+        columnExists:
+          tableName: monitoring
+          columnName: excluded_dates
+    changes:
+    - addColumn:
+        tableName: monitoring
+        columns:
+        - column:
+            name: excluded_dates
+            type: VARCHAR(2048)

--- a/server/src/main/resources/db/liquibase-changelog.yml
+++ b/server/src/main/resources/db/liquibase-changelog.yml
@@ -23,3 +23,6 @@ databaseChangeLog:
 - include:
       file: changelog/07-add-rehab-columns-to-monitoring.yml
       relativeToChangelogFile: true
+- include:
+      file: changelog/08-add-monitoring-clinic-list-and-exclusions.yml
+      relativeToChangelogFile: true

--- a/server/src/main/resources/db/liquibase-changelog.yml
+++ b/server/src/main/resources/db/liquibase-changelog.yml
@@ -29,3 +29,6 @@ databaseChangeLog:
 - include:
       file: changelog/09-add-monitoring-clinic-selection.yml
       relativeToChangelogFile: true
+- include:
+      file: changelog/10-ensure-monitoring-clinic-list-and-exclusions.yml
+      relativeToChangelogFile: true

--- a/server/src/main/resources/db/liquibase-changelog.yml
+++ b/server/src/main/resources/db/liquibase-changelog.yml
@@ -26,3 +26,6 @@ databaseChangeLog:
 - include:
       file: changelog/08-add-monitoring-clinic-list-and-exclusions.yml
       relativeToChangelogFile: true
+- include:
+      file: changelog/09-add-monitoring-clinic-selection.yml
+      relativeToChangelogFile: true

--- a/server/src/main/scala/com/lbs/server/BootConfig.scala
+++ b/server/src/main/scala/com/lbs/server/BootConfig.scala
@@ -79,8 +79,7 @@ class BootConfig {
       datePickerFactory,
       timePickerFactory,
       referralPagerFactory,
-      locationPagerFactory,
-      facilityPagerFactory,
+      staticDataFactory,
       rehabPhysiotherapistPagerFactory,
       termsPagerFactory
     )(actorSystem)

--- a/server/src/main/scala/com/lbs/server/conversation/Book.scala
+++ b/server/src/main/scala/com/lbs/server/conversation/Book.scala
@@ -4,7 +4,7 @@ import com.lbs.api.json.model.*
 import com.lbs.bot.*
 import com.lbs.bot.model.{Button, Command}
 import com.lbs.server.conversation.Book.*
-import com.lbs.server.conversation.DatePicker.{DateFromMode, DateToMode}
+import com.lbs.server.conversation.DatePicker.{DateFromMode, DateRange, DateToMode}
 import com.lbs.server.conversation.Login.UserId
 import com.lbs.server.conversation.Pager.SimpleItemsProvider
 import com.lbs.server.conversation.StaticData.StaticDataConfig
@@ -17,7 +17,9 @@ import com.lbs.server.util.MessageExtractors.*
 import com.lbs.server.util.ServerModelConverters.*
 import org.apache.pekko.actor.ActorSystem
 
-import java.time.{LocalDateTime, LocalTime}
+import java.time.{DayOfWeek, LocalDate, LocalDateTime, LocalTime, MonthDay}
+import java.time.format.DateTimeFormatter
+import scala.util.Try
 
 class Book(
   val userId: UserId,
@@ -65,9 +67,32 @@ class Book(
       withFunctions[IdName](
         latestOptions = dataService.getLatestClinicsByCityId(userId.accountId, bd.cityId.id),
         staticOptions = apiService.getAllFacilities(userId.accountId, bd.cityId.id, bd.serviceId.id),
-        applyId = id => bd.copy(clinicId = id)
+        applyId = id => bd.withClinic(id)
       )
-    }(requestNext = askDoctor)
+    }(requestNext = continueAfterClinic)
+
+  private def continueAfterClinic: Step =
+    process { bookingData =>
+      if (bookingData.hasAnyClinic) goto(askDoctor)
+      else goto(askAddAnotherClinic)
+    }
+
+  private def askAddAnotherClinic: Step =
+    ask { bookingData =>
+      bot.sendMessage(
+        userId.source,
+        lang.selectedClinics(bookingData),
+        inlineKeyboard =
+          createInlineKeyboard(
+            Seq(Button(lang.addAnotherClinic, Tags.AddAnotherClinic), Button(lang.continueBooking, Tags.Continue))
+          )
+      )
+    } onReply {
+      case Msg(CallbackCommand(Tags.AddAnotherClinic), _) =>
+        goto(askClinic)
+      case Msg(CallbackCommand(Tags.Continue), _) =>
+        goto(askDoctor)
+    }
 
   private def askDoctor: Step =
     staticData(doctorConfig) { (bd: BookingData) =>
@@ -75,15 +100,15 @@ class Book(
         latestOptions = dataService.getLatestDoctorsByCityIdAndClinicIdAndServiceId(
           userId.accountId,
           bd.cityId.id,
-          bd.clinicId.optionalId,
+          bd.singleClinicId,
           bd.serviceId.id
         ),
         staticOptions = apiService
           .getAllDoctors(userId.accountId, bd.cityId.id, bd.serviceId.id)
           .map(
               _.filter(doc => {
-                val clinicId = bd.clinicId.optionalId
-                clinicId.isEmpty || doc.facilityGroupIds.exists(_.contains(clinicId.get))
+                val clinicIds = bd.clinicFilter
+                clinicIds.isEmpty || doc.facilityGroupIds.exists(ids => clinicIds.exists(ids.contains))
               })
               .map(_.toIdName)
           ),
@@ -100,6 +125,8 @@ class Book(
       case Msg(cmd: Command, _) =>
         datePicker ! cmd
         stay()
+      case Msg(dateRange: DateRange, bookingData: BookingData) =>
+        goto(requestTimeFrom).using(bookingData.copy(dateFrom = dateRange.from, dateTo = dateRange.to))
       case Msg(date: LocalDateTime, bookingData: BookingData) =>
         goto(requestDateTo).using(bookingData.copy(dateFrom = date))
     }
@@ -164,17 +191,7 @@ class Book(
 
   private def requestTerm: Step =
     ask { bookingData =>
-      val availableTerms = apiService.getAvailableTerms(
-        userId.accountId,
-        bookingData.cityId.id,
-        bookingData.clinicId.optionalId,
-        bookingData.serviceId.id,
-        bookingData.doctorId.optionalId,
-        bookingData.dateFrom,
-        bookingData.dateTo,
-        timeFrom = bookingData.timeFrom,
-        timeTo = bookingData.timeTo
-      )
+      val availableTerms = getAvailableTerms(bookingData)
       termsPager.restart()
       termsPager ! availableTerms.map(new SimpleItemsProvider(_))
     } onReply {
@@ -249,7 +266,7 @@ class Book(
         }
         val newData = bookingData.copy(offset = defaultOffset)
         if (askOffset) goto(askMonitoringOffsetOption).using(newData)
-        else goto(askMonitoringAutobookOption).using(newData)
+        else goto(askMonitoringExclusionsOption).using(newData)
     }
 
   private def awaitRebookDecision: Step =
@@ -316,9 +333,60 @@ class Book(
       )
     } onReply {
       case Msg(TextCommand(IntString(offset)), bookingData: BookingData) =>
-        goto(askMonitoringAutobookOption).using(bookingData.copy(offset = offset))
+        goto(askMonitoringExclusionsOption).using(bookingData.copy(offset = offset))
+      case Msg(CallbackCommand(BooleanString(false)), _) =>
+        goto(askMonitoringExclusionsOption)
+    }
+
+  private def askMonitoringExclusionsOption: Step =
+    ask { _ =>
+      bot.sendMessage(
+        userId.source,
+        lang.addMonitoringExclusions,
+        inlineKeyboard = createInlineKeyboard(Seq(Button(lang.no, Tags.No), Button(lang.yes, Tags.Yes)))
+      )
+    } onReply {
+      case Msg(CallbackCommand(BooleanString(true)), _) =>
+        goto(askExcludedWeekdays)
       case Msg(CallbackCommand(BooleanString(false)), _) =>
         goto(askMonitoringAutobookOption)
+    }
+
+  private def askExcludedWeekdays: Step =
+    ask { bookingData =>
+      bot.sendMessage(
+        userId.source,
+        lang.chooseExcludedWeekdays(bookingData.excludedWeekdays),
+        inlineKeyboard = excludedWeekdayKeyboard(bookingData.excludedWeekdays)
+      )
+    } onReply {
+      case Msg(CallbackCommand(Tags.Done), _) =>
+        goto(askExcludedDates)
+      case Msg(CallbackCommand(WeekdayTag(dayOfWeek)), bookingData: BookingData) =>
+        val weekdays =
+          if (bookingData.excludedWeekdays.contains(dayOfWeek)) bookingData.excludedWeekdays - dayOfWeek
+          else bookingData.excludedWeekdays + dayOfWeek
+        goto(askExcludedWeekdays).using(bookingData.copy(excludedWeekdays = weekdays))
+    }
+
+  private def askExcludedDates: Step =
+    ask { _ =>
+      bot.sendMessage(
+        userId.source,
+        lang.pleaseEnterExcludedDates,
+        inlineKeyboard = createInlineKeyboard(Seq(Button(lang.no, Tags.No)))
+      )
+    } onReply {
+      case Msg(CallbackCommand(BooleanString(false)), _) =>
+        goto(askMonitoringAutobookOption)
+      case Msg(TextCommand(text), bookingData: BookingData) =>
+        parseExcludedDates(text, bookingData.dateFrom.toLocalDate) match {
+          case Right(dates) =>
+            goto(askMonitoringAutobookOption).using(bookingData.copy(excludedDates = dates.toSet))
+          case Left(error) =>
+            bot.sendMessage(userId.source, lang.unableToParseExcludedDates(error))
+            stay()
+        }
     }
 
   private def askMonitoringAutobookOption: Step =
@@ -362,6 +430,52 @@ class Book(
       end()
     }
 
+  private def getAvailableTerms(bookingData: BookingData): Either[Throwable, List[TermExt]] = {
+    val selectedClinicIds = bookingData.clinicFilter
+    apiService.getAvailableTerms(
+      userId.accountId,
+      bookingData.cityId.id,
+      bookingData.singleClinicId,
+      bookingData.serviceId.id,
+      bookingData.doctorId.optionalId,
+      bookingData.dateFrom,
+      bookingData.dateTo,
+      timeFrom = bookingData.timeFrom,
+      timeTo = bookingData.timeTo
+    ).map { terms =>
+      if (selectedClinicIds.size <= 1) terms
+      else terms.filter(term => selectedClinicIds.contains(term.term.clinicGroupId))
+    }.map(_.sortBy(_.term.dateTimeFrom.get.toString))
+  }
+
+  private def excludedWeekdayKeyboard(excludedWeekdays: Set[DayOfWeek]) = {
+    val weekdays = DayOfWeek.values().toSeq
+    val buttons = weekdays.map { day =>
+      val label = s"${if (excludedWeekdays.contains(day)) "✅ " else ""}${lang.weekdayName(day)}"
+      Button(label, Tags.WeekdayPrefix + day.getValue)
+    }
+    createInlineKeyboard(buttons :+ Button(lang.done, Tags.Done), columns = 2)
+  }
+
+  private def parseExcludedDates(text: String, dateFrom: LocalDate): Either[String, Seq[LocalDate]] = {
+    val parts = text.split("[,;\\s]+").map(_.trim).filter(_.nonEmpty).toSeq
+    val parsed = parts.map(parseExcludedDate(_, dateFrom))
+    parsed.collectFirst { case Left(error) => error } match {
+      case Some(error) => Left(error)
+      case None        => Right(parsed.collect { case Right(date) => date }.distinct)
+    }
+  }
+
+  private def parseExcludedDate(text: String, dateFrom: LocalDate): Either[String, LocalDate] = {
+    val iso = Try(LocalDate.parse(text)).toOption
+    val dayMonth = Try {
+      val parsed = MonthDay.parse(text, DateTimeFormatter.ofPattern("dd-MM"))
+      val date = parsed.atYear(dateFrom.getYear)
+      if (date.isBefore(dateFrom)) date.plusYears(1) else date
+    }.toOption
+    iso.orElse(dayMonth).toRight(text)
+  }
+
   private def cityConfig = StaticDataConfig(lang.city, "wro", "Wrocław", isAnyAllowed = false)
 
   private def clinicConfig = StaticDataConfig(lang.clinic, "swob", "Swobodna 1", isAnyAllowed = true)
@@ -383,6 +497,7 @@ object Book {
   case class BookingData(
     cityId: IdName = null,
     clinicId: IdName = null,
+    clinicIds: Seq[IdName] = Seq(),
     serviceId: IdName = null,
     doctorId: IdName = null,
     dateFrom: LocalDateTime = LocalDateTime.now(),
@@ -396,8 +511,36 @@ object Book {
     offset: Int = 0,
     payerId: Long = 0,
     payers: Seq[IdName] = Seq(),
-    xsrfToken: Option[XsrfToken] = None
-  )
+    xsrfToken: Option[XsrfToken] = None,
+    excludedWeekdays: Set[DayOfWeek] = Set.empty,
+    excludedDates: Set[LocalDate] = Set.empty
+  ) {
+    def selectedClinics: Seq[IdName] = {
+      if (clinicIds.nonEmpty) clinicIds
+      else Option(clinicId).toSeq
+    }
+
+    def clinicOptions: Seq[Option[Long]] = selectedClinics.map(_.optionalId) match {
+      case Nil => Seq(None)
+      case xs  => xs
+    }
+
+    def clinicFilter: Seq[Long] = clinicOptions.flatten.distinct
+
+    def singleClinicId: Option[Long] = {
+      val selected = clinicOptions.distinct
+      if (selected.size == 1) selected.head else None
+    }
+
+    def hasAnyClinic: Boolean = clinicOptions.exists(_.isEmpty)
+
+    def withClinic(clinic: IdName): BookingData = {
+      val updatedClinics =
+        if (clinic.optionalId.isEmpty) Seq(clinic)
+        else (selectedClinics.filter(_.optionalId.nonEmpty) :+ clinic).distinctBy(_.id)
+      copy(clinicId = updatedClinics.head, clinicIds = updatedClinics)
+    }
+  }
 
   object Tags {
     val Cancel = "cancel"
@@ -409,6 +552,19 @@ object Book {
     val BookByApplication = "true"
     val Yes = "true"
     val No = "false"
+    val AddAnotherClinic = "add_another_clinic"
+    val Continue = "continue"
+    val Done = "done"
+    val WeekdayPrefix = "weekday_"
+  }
+
+  object WeekdayTag {
+    def unapply(tag: String): Option[DayOfWeek] =
+      tag.stripPrefix(Tags.WeekdayPrefix) match {
+        case value if tag.startsWith(Tags.WeekdayPrefix) =>
+          Try(DayOfWeek.of(value.toInt)).toOption
+        case _ => None
+      }
   }
 
 }

--- a/server/src/main/scala/com/lbs/server/conversation/Book.scala
+++ b/server/src/main/scala/com/lbs/server/conversation/Book.scala
@@ -126,9 +126,18 @@ class Book(
         datePicker ! cmd
         stay()
       case Msg(dateRange: DateRange, bookingData: BookingData) =>
-        goto(requestTimeFrom).using(bookingData.copy(dateFrom = dateRange.from, dateTo = dateRange.to))
+        goto(askExcludedWeekdays).using(bookingData.copy(
+          dateFrom = dateRange.from,
+          dateTo = dateRange.to,
+          excludedWeekdays = Set.empty,
+          excludedDates = Set.empty
+        ))
       case Msg(date: LocalDateTime, bookingData: BookingData) =>
-        goto(requestDateTo).using(bookingData.copy(dateFrom = date))
+        goto(requestDateTo).using(bookingData.copy(
+          dateFrom = date,
+          excludedWeekdays = Set.empty,
+          excludedDates = Set.empty
+        ))
     }
 
   private def requestDateTo: Step =
@@ -141,7 +150,7 @@ class Book(
         datePicker ! cmd
         stay()
       case Msg(date: LocalDateTime, bookingData: BookingData) =>
-        goto(requestTimeFrom).using(bookingData.copy(dateTo = date))
+        goto(askExcludedWeekdays).using(bookingData.copy(dateTo = date))
     }
 
   private def requestTimeFrom: Step =
@@ -185,7 +194,9 @@ class Book(
       case Msg(CallbackCommand(Tags.ModifyDate), bookingData) =>
         goto(requestDateFrom).using(bookingData.copy(
           dateFrom = LocalDateTime.now(),
-          dateTo = LocalDateTime.now().plusDays(1L)
+          dateTo = LocalDateTime.now().plusDays(1L),
+          excludedWeekdays = Set.empty,
+          excludedDates = Set.empty
         ))
     }
 
@@ -256,7 +267,9 @@ class Book(
       case Msg(CallbackCommand(Tags.ModifyDate), bookingData) =>
         goto(requestDateFrom).using(bookingData.copy(
           dateFrom = LocalDateTime.now(),
-          dateTo = LocalDateTime.now().plusDays(1L)
+          dateTo = LocalDateTime.now().plusDays(1L),
+          excludedWeekdays = Set.empty,
+          excludedDates = Set.empty
         ))
       case Msg(CallbackCommand(Tags.CreateMonitoring), bookingData) =>
         val settingsMaybe = dataService.findSettings(userId.userId)
@@ -266,7 +279,7 @@ class Book(
         }
         val newData = bookingData.copy(offset = defaultOffset)
         if (askOffset) goto(askMonitoringOffsetOption).using(newData)
-        else goto(askMonitoringExclusionsOption).using(newData)
+        else goto(askMonitoringAutobookOption).using(newData)
     }
 
   private def awaitRebookDecision: Step =
@@ -333,21 +346,7 @@ class Book(
       )
     } onReply {
       case Msg(TextCommand(IntString(offset)), bookingData: BookingData) =>
-        goto(askMonitoringExclusionsOption).using(bookingData.copy(offset = offset))
-      case Msg(CallbackCommand(BooleanString(false)), _) =>
-        goto(askMonitoringExclusionsOption)
-    }
-
-  private def askMonitoringExclusionsOption: Step =
-    ask { _ =>
-      bot.sendMessage(
-        userId.source,
-        lang.addMonitoringExclusions,
-        inlineKeyboard = createInlineKeyboard(Seq(Button(lang.no, Tags.No), Button(lang.yes, Tags.Yes)))
-      )
-    } onReply {
-      case Msg(CallbackCommand(BooleanString(true)), _) =>
-        goto(askExcludedWeekdays)
+        goto(askMonitoringAutobookOption).using(bookingData.copy(offset = offset))
       case Msg(CallbackCommand(BooleanString(false)), _) =>
         goto(askMonitoringAutobookOption)
     }
@@ -378,11 +377,11 @@ class Book(
       )
     } onReply {
       case Msg(CallbackCommand(BooleanString(false)), _) =>
-        goto(askMonitoringAutobookOption)
+        goto(requestTimeFrom)
       case Msg(TextCommand(text), bookingData: BookingData) =>
         parseExcludedDates(text, bookingData.dateFrom.toLocalDate) match {
           case Right(dates) =>
-            goto(askMonitoringAutobookOption).using(bookingData.copy(excludedDates = dates.toSet))
+            goto(requestTimeFrom).using(bookingData.copy(excludedDates = dates.toSet))
           case Left(error) =>
             bot.sendMessage(userId.source, lang.unableToParseExcludedDates(error))
             stay()
@@ -445,7 +444,9 @@ class Book(
     ).map { terms =>
       if (selectedClinicIds.size <= 1) terms
       else terms.filter(term => selectedClinicIds.contains(term.term.clinicGroupId))
-    }.map(_.sortBy(_.term.dateTimeFrom.get.toString))
+    }.map(_.filterNot(term => bookingData.excludedWeekdays.contains(term.term.dateTimeFrom.get.getDayOfWeek)))
+      .map(_.filterNot(term => bookingData.excludedDates.contains(term.term.dateTimeFrom.get.toLocalDate)))
+      .map(_.sortBy(_.term.dateTimeFrom.get))
   }
 
   private def excludedWeekdayKeyboard(excludedWeekdays: Set[DayOfWeek]) = {

--- a/server/src/main/scala/com/lbs/server/conversation/BookWithTemplate.scala
+++ b/server/src/main/scala/com/lbs/server/conversation/BookWithTemplate.scala
@@ -43,12 +43,15 @@ class BookWithTemplate(
       val bookingData = BookingData(
         cityId = IdName.from(monitoring.cityId, monitoring.cityName),
         clinicId = IdName.from(monitoring.clinicId, monitoring.clinicName),
+        clinicIds = monitoring.clinics.map { case (id, name) => IdName(id.getOrElse(-1L), name) },
         serviceId = IdName.from(monitoring.serviceId, monitoring.serviceName),
         doctorId = IdName.from(monitoring.doctorId, monitoring.doctorName),
         dateFrom = monitoring.dateFrom.toLocalDateTime,
         dateTo = monitoring.dateTo.toLocalDateTime,
         timeFrom = monitoring.timeFrom,
-        timeTo = monitoring.timeTo
+        timeTo = monitoring.timeTo,
+        excludedWeekdays = monitoring.excludedWeekdaysSet,
+        excludedDates = monitoring.excludedDatesSet
       )
       goto(requestDateFrom).using(bookingData)
     }
@@ -126,17 +129,7 @@ class BookWithTemplate(
 
   private def requestTerm: Step =
     ask { bookingData =>
-      val availableTerms = apiService.getAvailableTerms(
-        userId.accountId,
-        bookingData.cityId.id,
-        bookingData.clinicId.optionalId,
-        bookingData.serviceId.id,
-        bookingData.doctorId.optionalId,
-        bookingData.dateFrom,
-        bookingData.dateTo,
-        timeFrom = bookingData.timeFrom,
-        timeTo = bookingData.timeTo
-      )
+      val availableTerms = getAvailableTerms(bookingData)
       termsPager.restart()
       termsPager ! availableTerms.map(new SimpleItemsProvider(_))
     } onReply {
@@ -312,6 +305,30 @@ class BookWithTemplate(
       }
       end()
     }
+
+  private def getAvailableTerms(bookingData: BookingData): Either[Throwable, List[TermExt]] = {
+    bookingData.clinicOptions.foldLeft[Either[Throwable, List[TermExt]]](Right(Nil)) { (acc, clinicId) =>
+      for {
+        terms <- acc
+        next <- apiService.getAvailableTerms(
+          userId.accountId,
+          bookingData.cityId.id,
+          clinicId,
+          bookingData.serviceId.id,
+          bookingData.doctorId.optionalId,
+          bookingData.dateFrom,
+          bookingData.dateTo,
+          timeFrom = bookingData.timeFrom,
+          timeTo = bookingData.timeTo
+        )
+      } yield terms ++ next
+    }.map(terms =>
+      terms
+        .filterNot(term => bookingData.excludedWeekdays.contains(term.term.dateTimeFrom.get.getDayOfWeek))
+        .filterNot(term => bookingData.excludedDates.contains(term.term.dateTimeFrom.get.toLocalDate))
+        .sortBy(_.term.dateTimeFrom.get.toString)
+    )
+  }
 
   beforeDestroy {
     datePicker.destroy()

--- a/server/src/main/scala/com/lbs/server/conversation/BookWithTemplate.scala
+++ b/server/src/main/scala/com/lbs/server/conversation/BookWithTemplate.scala
@@ -4,7 +4,7 @@ import com.lbs.api.json.model.*
 import com.lbs.bot.*
 import com.lbs.bot.model.{Button, Command}
 import com.lbs.server.conversation.Book.*
-import com.lbs.server.conversation.DatePicker.{DateFromMode, DateToMode}
+import com.lbs.server.conversation.DatePicker.{DateFromMode, DateRange, DateToMode}
 import com.lbs.server.conversation.Login.UserId
 import com.lbs.server.conversation.Pager.SimpleItemsProvider
 import com.lbs.server.conversation.TimePicker.{TimeFromMode, TimeToMode}
@@ -65,8 +65,19 @@ class BookWithTemplate(
       case Msg(cmd: Command, _) =>
         datePicker ! cmd
         stay()
+      case Msg(dateRange: DateRange, bookingData: BookingData) =>
+        goto(requestTimeFrom).using(bookingData.copy(
+          dateFrom = dateRange.from,
+          dateTo = dateRange.to,
+          excludedWeekdays = Set.empty,
+          excludedDates = Set.empty
+        ))
       case Msg(date: LocalDateTime, bookingData: BookingData) =>
-        goto(requestDateTo).using(bookingData.copy(dateFrom = date))
+        goto(requestDateTo).using(bookingData.copy(
+          dateFrom = date,
+          excludedWeekdays = Set.empty,
+          excludedDates = Set.empty
+        ))
     }
 
   private def requestDateTo: Step =
@@ -123,7 +134,9 @@ class BookWithTemplate(
       case Msg(CallbackCommand(Tags.ModifyDate), bookingData) =>
         goto(requestDateFrom).using(bookingData.copy(
           dateFrom = LocalDateTime.now(),
-          dateTo = LocalDateTime.now().plusDays(1L)
+          dateTo = LocalDateTime.now().plusDays(1L),
+          excludedWeekdays = Set.empty,
+          excludedDates = Set.empty
         ))
     }
 
@@ -183,7 +196,9 @@ class BookWithTemplate(
       case Msg(CallbackCommand(Tags.ModifyDate), bookingData) =>
         goto(requestDateFrom).using(bookingData.copy(
           dateFrom = LocalDateTime.now(),
-          dateTo = LocalDateTime.now().plusDays(1L)
+          dateTo = LocalDateTime.now().plusDays(1L),
+          excludedWeekdays = Set.empty,
+          excludedDates = Set.empty
         ))
       case Msg(CallbackCommand(Tags.CreateMonitoring), bookingData) =>
         val settingsMaybe = dataService.findSettings(userId.userId)
@@ -307,28 +322,28 @@ class BookWithTemplate(
     }
 
   private def getAvailableTerms(bookingData: BookingData): Either[Throwable, List[TermExt]] = {
-    bookingData.clinicOptions.foldLeft[Either[Throwable, List[TermExt]]](Right(Nil)) { (acc, clinicId) =>
-      for {
-        terms <- acc
-        next <- apiService.getAvailableTerms(
-          userId.accountId,
-          bookingData.cityId.id,
-          clinicId,
-          bookingData.serviceId.id,
-          bookingData.doctorId.optionalId,
-          bookingData.dateFrom,
-          bookingData.dateTo,
-          timeFrom = bookingData.timeFrom,
-          timeTo = bookingData.timeTo
-        )
-      } yield terms ++ next
-    }.map(terms =>
+    val selectedClinicIds = bookingData.clinicFilter
+    apiService.getAvailableTerms(
+      userId.accountId,
+      bookingData.cityId.id,
+      bookingData.singleClinicId,
+      bookingData.serviceId.id,
+      bookingData.doctorId.optionalId,
+      bookingData.dateFrom,
+      bookingData.dateTo,
+      timeFrom = bookingData.timeFrom,
+      timeTo = bookingData.timeTo
+    ).map(filterSelectedClinics(_, selectedClinicIds)).map(terms =>
       terms
         .filterNot(term => bookingData.excludedWeekdays.contains(term.term.dateTimeFrom.get.getDayOfWeek))
         .filterNot(term => bookingData.excludedDates.contains(term.term.dateTimeFrom.get.toLocalDate))
-        .sortBy(_.term.dateTimeFrom.get.toString)
+        .sortBy(_.term.dateTimeFrom.get)
     )
   }
+
+  private def filterSelectedClinics(terms: List[TermExt], clinicIds: Seq[Long]): List[TermExt] =
+    if (clinicIds.size <= 1) terms
+    else terms.filter(term => clinicIds.contains(term.term.clinicGroupId))
 
   beforeDestroy {
     datePicker.destroy()

--- a/server/src/main/scala/com/lbs/server/conversation/BookWithTemplate.scala
+++ b/server/src/main/scala/com/lbs/server/conversation/BookWithTemplate.scala
@@ -68,16 +68,10 @@ class BookWithTemplate(
       case Msg(dateRange: DateRange, bookingData: BookingData) =>
         goto(requestTimeFrom).using(bookingData.copy(
           dateFrom = dateRange.from,
-          dateTo = dateRange.to,
-          excludedWeekdays = Set.empty,
-          excludedDates = Set.empty
+          dateTo = dateRange.to
         ))
       case Msg(date: LocalDateTime, bookingData: BookingData) =>
-        goto(requestDateTo).using(bookingData.copy(
-          dateFrom = date,
-          excludedWeekdays = Set.empty,
-          excludedDates = Set.empty
-        ))
+        goto(requestDateTo).using(bookingData.copy(dateFrom = date))
     }
 
   private def requestDateTo: Step =
@@ -134,9 +128,7 @@ class BookWithTemplate(
       case Msg(CallbackCommand(Tags.ModifyDate), bookingData) =>
         goto(requestDateFrom).using(bookingData.copy(
           dateFrom = LocalDateTime.now(),
-          dateTo = LocalDateTime.now().plusDays(1L),
-          excludedWeekdays = Set.empty,
-          excludedDates = Set.empty
+          dateTo = LocalDateTime.now().plusDays(1L)
         ))
     }
 
@@ -196,9 +188,7 @@ class BookWithTemplate(
       case Msg(CallbackCommand(Tags.ModifyDate), bookingData) =>
         goto(requestDateFrom).using(bookingData.copy(
           dateFrom = LocalDateTime.now(),
-          dateTo = LocalDateTime.now().plusDays(1L),
-          excludedWeekdays = Set.empty,
-          excludedDates = Set.empty
+          dateTo = LocalDateTime.now().plusDays(1L)
         ))
       case Msg(CallbackCommand(Tags.CreateMonitoring), bookingData) =>
         val settingsMaybe = dataService.findSettings(userId.userId)

--- a/server/src/main/scala/com/lbs/server/conversation/DatePicker.scala
+++ b/server/src/main/scala/com/lbs/server/conversation/DatePicker.scala
@@ -11,7 +11,7 @@ import com.lbs.server.util.MessageExtractors.{CallbackCommand, TextCommand}
 import org.apache.pekko.actor.ActorSystem
 
 import java.time.format.TextStyle
-import java.time.{LocalDateTime, LocalTime}
+import java.time.{LocalDate, LocalDateTime, LocalTime, MonthDay}
 import scala.util.control.NonFatal
 
 /**
@@ -47,6 +47,12 @@ class DatePicker(val userId: UserId, val bot: Bot, val localization: Localizatio
       }
       bot.sendMessage(userId.source, message, inlineKeyboard = dateButtons(initialDate))
     } onReply {
+      case Msg(cmd @ CallbackCommand(QuickRange(rangeFactory)), _) if mode == DateFromMode =>
+        val selectedRange = rangeFactory()
+        val normalizedRange = range(selectedRange.from, selectedRange.to)
+        bot.sendEditMessage(userId.source, cmd.message.messageId, lang.dateRangeIs(normalizedRange.from, normalizedRange.to))
+        originator ! normalizedRange
+        end()
       case Msg(cmd @ CallbackCommand(Tags.Done), finalDate) =>
         val (message, updatedDate) = mode match {
           case DateFromMode =>
@@ -60,22 +66,32 @@ class DatePicker(val userId: UserId, val bot: Bot, val localization: Localizatio
         bot.sendEditMessage(userId.source, cmd.message.messageId, message)
         originator ! updatedDate
         end()
-      case Msg(TextCommand(dayMonth), finalDate) =>
+      case Msg(TextCommand(text), finalDate) =>
         try {
-          val updatedDate = applyDayMonth(dayMonth, finalDate)
-          val message = mode match {
-            case DateFromMode =>
-              lang.dateFromIs(updatedDate)
-            case DateToMode =>
-              lang.dateToIs(updatedDate)
+          parseTextDate(text, finalDate) match {
+            case ParsedDateRange(range) if mode == DateFromMode =>
+              bot.sendMessage(userId.source, lang.dateRangeIs(range.from, range.to))
+              originator ! range
+            case ParsedDate(date) =>
+              val message = mode match {
+                case DateFromMode =>
+                  lang.dateFromIs(normalizeDateFrom(date))
+                case DateToMode =>
+                  lang.dateToIs(normalizeDateTo(date))
+              }
+              bot.sendMessage(userId.source, message)
+              originator ! (mode match {
+                case DateFromMode => normalizeDateFrom(date)
+                case DateToMode   => normalizeDateTo(date)
+              })
+            case ParsedDateRange(_) =>
+              throw IllegalArgumentException("Date range is allowed only for date from")
           }
-          bot.sendMessage(userId.source, message)
-          originator ! updatedDate
           end()
         } catch {
           case NonFatal(ex) =>
             logger.error("Unable to parse date", ex)
-            bot.sendMessage(userId.source, "Incorrect date. Please use format dd-MM")
+            bot.sendMessage(userId.source, lang.incorrectDateFormat)
             goto(requestDate)
         }
       case Msg(cmd @ CallbackCommand(tag), date) =>
@@ -102,18 +118,77 @@ class DatePicker(val userId: UserId, val bot: Bot, val localization: Localizatio
     val month = date.getMonth.getDisplayName(TextStyle.SHORT, lang.locale)
     val year = date.getYear.toString
 
+    val quickRangeButtons =
+      if (mode == DateFromMode)
+        Seq(
+          Seq(Button(lang.quickRangeToday, Tags.Today), Button(lang.quickRangeTomorrow, Tags.Tomorrow)),
+          Seq(Button(lang.quickRangeNext7Days, Tags.Next7Days), Button(lang.quickRangeNext14Days, Tags.Next14Days))
+        )
+      else Seq.empty
+
     createInlineKeyboard(
-      Seq(
+      quickRangeButtons ++ Seq(
         Seq(Button("⬆", Tags.DayInc), Button("⬆", Tags.MonthInc), Button("⬆", Tags.YearInc)),
         Seq(Button(s"$day ($dayOfWeek)"), Button(month), Button(year)),
         Seq(Button("⬇", Tags.DayDec), Button("⬇", Tags.MonthDec), Button("⬇", Tags.YearDec)),
-        Seq(Button("Done", Tags.Done))
+        Seq(Button(lang.done, Tags.Done))
       )
     )
+  }
+
+  private def normalizeDateFrom(date: LocalDateTime): LocalDateTime = {
+    val now = LocalDateTime.now()
+    val startOfTheDay = date.`with`(LocalTime.MIN)
+    if (startOfTheDay.isBefore(now) && date.toLocalDate == now.toLocalDate) now
+    else if (startOfTheDay.isBefore(now)) date
+    else startOfTheDay
+  }
+
+  private def normalizeDateTo(date: LocalDateTime): LocalDateTime =
+    date.`with`(LocalTime.MAX).minusHours(2)
+
+  private def range(from: LocalDateTime, to: LocalDateTime): DateRange =
+    DateRange(normalizeDateFrom(from), normalizeDateTo(to))
+
+  private def parseTextDate(text: String, initialDate: LocalDateTime): ParsedTextDate = {
+    val tokens = DateToken.findAllIn(text).toSeq
+    tokens match {
+      case first +: second +: _ =>
+        val from = parseDateToken(first, initialDate.toLocalDate)
+        val to = parseDateToken(second, from.toLocalDate)
+        ParsedDateRange(range(from, to))
+      case Seq(single) =>
+        ParsedDate(parseDateToken(single, initialDate.toLocalDate))
+      case _ =>
+        throw IllegalArgumentException(s"Unable to parse date '$text'")
+    }
+  }
+
+  private def parseDateToken(token: String, baseDate: LocalDate): LocalDateTime = {
+    val date =
+      if (token.matches("\\d{4}-\\d{1,2}-\\d{1,2}")) {
+        val parts = token.split("-").map(_.toInt)
+        LocalDate.of(parts(0), parts(1), parts(2))
+      } else {
+        val parts = token.split("-").map(_.toInt)
+        val candidate = MonthDay.of(parts(1), parts(0)).atYear(baseDate.getYear)
+        if (candidate.isBefore(baseDate)) candidate.plusYears(1) else candidate
+      }
+    date.atStartOfDay()
   }
 }
 
 object DatePicker {
+
+  case class DateRange(from: LocalDateTime, to: LocalDateTime)
+
+  private val DateToken = "\\d{4}-\\d{1,2}-\\d{1,2}|\\d{1,2}-\\d{1,2}".r
+
+  private trait ParsedTextDate
+
+  private case class ParsedDate(date: LocalDateTime) extends ParsedTextDate
+
+  private case class ParsedDateRange(range: DateRange) extends ParsedTextDate
 
   trait Mode
 
@@ -122,6 +197,10 @@ object DatePicker {
   object DateToMode extends Mode
 
   object Tags {
+    val Today = "today"
+    val Tomorrow = "tomorrow"
+    val Next7Days = "next_7_days"
+    val Next14Days = "next_14_days"
     val DayInc = "day_inc"
     val MonthInc = "month_inc"
     val YearInc = "year_inc"
@@ -129,6 +208,24 @@ object DatePicker {
     val MonthDec = "month_dec"
     val YearDec = "year_dec"
     val Done = "done"
+  }
+
+  object QuickRange {
+    def unapply(tag: String): Option[() => DateRange] =
+      tag match {
+        case Tags.Today =>
+          Some(() => DateRange(LocalDateTime.now(), LocalDateTime.now()))
+        case Tags.Tomorrow =>
+          Some(() => {
+            val tomorrow = LocalDate.now().plusDays(1).atStartOfDay()
+            DateRange(tomorrow, tomorrow)
+          })
+        case Tags.Next7Days =>
+          Some(() => DateRange(LocalDateTime.now(), LocalDateTime.now().plusDays(7)))
+        case Tags.Next14Days =>
+          Some(() => DateRange(LocalDateTime.now(), LocalDateTime.now().plusDays(14)))
+        case _ => None
+      }
   }
 
 }

--- a/server/src/main/scala/com/lbs/server/conversation/DatePicker.scala
+++ b/server/src/main/scala/com/lbs/server/conversation/DatePicker.scala
@@ -56,11 +56,10 @@ class DatePicker(val userId: UserId, val bot: Bot, val localization: Localizatio
       case Msg(cmd @ CallbackCommand(Tags.Done), finalDate) =>
         val (message, updatedDate) = mode match {
           case DateFromMode =>
-            val startOfTheDay = finalDate.`with`(LocalTime.MIN)
-            val dateFrom = if (startOfTheDay.isBefore(LocalDateTime.now())) finalDate else startOfTheDay
+            val dateFrom = normalizeDateFrom(finalDate)
             lang.dateFromIs(dateFrom) -> dateFrom
           case DateToMode =>
-            val dateTo = finalDate.`with`(LocalTime.MAX).minusHours(2)
+            val dateTo = normalizeDateTo(finalDate)
             lang.dateToIs(dateTo) -> dateTo
         }
         bot.sendEditMessage(userId.source, cmd.message.messageId, message)
@@ -145,17 +144,23 @@ class DatePicker(val userId: UserId, val bot: Bot, val localization: Localizatio
   }
 
   private def normalizeDateTo(date: LocalDateTime): LocalDateTime =
-    date.`with`(LocalTime.MAX).minusHours(2)
+    date.`with`(LocalTime.MAX)
 
-  private def range(from: LocalDateTime, to: LocalDateTime): DateRange =
-    DateRange(normalizeDateFrom(from), normalizeDateTo(to))
+  private def range(from: LocalDateTime, to: LocalDateTime): DateRange = {
+    val (first, second) =
+      if (from.toLocalDate.isAfter(to.toLocalDate)) to -> from
+      else from -> to
+    val dateFrom = normalizeDateFrom(first)
+    val dateTo = normalizeDateTo(second)
+    DateRange(dateFrom, if (dateTo.isBefore(dateFrom)) dateFrom else dateTo)
+  }
 
   private def parseTextDate(text: String, initialDate: LocalDateTime): ParsedTextDate = {
     val tokens = DateToken.findAllIn(text).toSeq
     tokens match {
       case first +: second +: _ =>
         val from = parseDateToken(first, initialDate.toLocalDate)
-        val to = parseDateToken(second, from.toLocalDate)
+        val to = parseDateToken(second, initialDate.toLocalDate)
         ParsedDateRange(range(from, to))
       case Seq(single) =>
         ParsedDate(parseDateToken(single, initialDate.toLocalDate))

--- a/server/src/main/scala/com/lbs/server/conversation/RehabBook.scala
+++ b/server/src/main/scala/com/lbs/server/conversation/RehabBook.scala
@@ -3,10 +3,11 @@ package com.lbs.server.conversation
 import com.lbs.api.json.model.*
 import com.lbs.bot.*
 import com.lbs.bot.model.{Button, Command}
-import com.lbs.server.conversation.DatePicker.{DateFromMode, DateToMode}
+import com.lbs.server.conversation.DatePicker.{DateFromMode, DateRange, DateToMode}
 import com.lbs.server.conversation.Login.UserId
 import com.lbs.server.conversation.Pager.SimpleItemsProvider
 import com.lbs.server.conversation.RehabBook.*
+import com.lbs.server.conversation.StaticData.{FindOptions, FoundOptions, LatestOptions, StaticDataConfig}
 import com.lbs.server.conversation.TimePicker.{TimeFromMode, TimeToMode}
 import com.lbs.server.conversation.base.Conversation
 import com.lbs.server.lang.{Localizable, Localization}
@@ -16,7 +17,9 @@ import com.lbs.server.util.MessageExtractors.*
 import com.lbs.server.util.ServerModelConverters.*
 import org.apache.pekko.actor.ActorSystem
 
-import java.time.{LocalDateTime, LocalTime}
+import java.time.format.DateTimeFormatter
+import java.time.{DayOfWeek, LocalDate, LocalDateTime, LocalTime, MonthDay}
+import scala.util.Try
 
 class RehabBook(
   val userId: UserId,
@@ -28,8 +31,7 @@ class RehabBook(
   datePickerFactory: UserIdWithOriginatorTo[DatePicker],
   timePickerFactory: UserIdWithOriginatorTo[TimePicker],
   referralPagerFactory: UserIdWithOriginatorTo[Pager[Referral]],
-  locationPagerFactory: UserIdWithOriginatorTo[Pager[RehabLocation]],
-  facilityPagerFactory: UserIdWithOriginatorTo[Pager[RehabFacility]],
+  staticDataFactory: UserIdWithOriginatorTo[StaticData],
   physiotherapistPagerFactory: UserIdWithOriginatorTo[Pager[IdName]],
   termsPagerFactory: UserIdWithOriginatorTo[Pager[TermExt]]
 )(val actorSystem: ActorSystem)
@@ -39,8 +41,7 @@ class RehabBook(
   private val datePicker = datePickerFactory(userId, self)
   private val timePicker = timePickerFactory(userId, self)
   private val referralPager = referralPagerFactory(userId, self)
-  private val locationPager = locationPagerFactory(userId, self)
-  private val facilityPager = facilityPagerFactory(userId, self)
+  private[conversation] val staticData = staticDataFactory(userId, self)
   private val physiotherapistPager = physiotherapistPagerFactory(userId, self)
   private val termsPager = termsPagerFactory(userId, self)
 
@@ -96,8 +97,6 @@ class RehabBook(
             bot.sendMessage(userId.source, ex.getMessage)
             end()
           case Right(facilities) =>
-            locationPager.restart()
-            locationPager ! Right(new SimpleItemsProvider(facilities.locations))
             goto(selectCity).using(newData.copy(rehabFacilities = Some(facilities)))
         }
     }
@@ -116,31 +115,47 @@ class RehabBook(
     }
 
   private def selectCity: Step =
-    ask { _ => () } onReply {
-      case Msg(cmd: Command, _) =>
-        locationPager ! cmd
-        stay()
-      case Msg(location: RehabLocation, data: RehabBookingData) =>
-        val newData = data.copy(cityId = location.toIdName)
-        val facilitiesForCity = data.rehabFacilities.map(_.facilities.filter(_.locationId == location.id)).getOrElse(Nil)
-        facilityPager.restart()
-        facilityPager ! Right(new SimpleItemsProvider(facilitiesForCity))
-        goto(selectFacility).using(newData)
-      case Msg(Pager.NoItemsFound, _) =>
-        bot.sendMessage(userId.source, lang.noRehabReferralsFound)
-        end()
-    }
+    staticData(rehabCityConfig) { data =>
+      val locations = data.rehabFacilities.map(_.locations).getOrElse(Nil)
+      staticOptions(
+        staticOptions = Right(locations),
+        applyId = city => data.copy(cityId = city)
+      )
+    }(requestNext = selectFacility)
 
   private def selectFacility: Step =
-    ask { _ => () } onReply {
-      case Msg(cmd: Command, _) =>
-        facilityPager ! cmd
-        stay()
-      case Msg(facility: RehabFacility, data: RehabBookingData) =>
-        goto(askPhysiotherapist).using(data.copy(facilityId = facility.toIdName))
-      case Msg(Pager.NoItemsFound, data: RehabBookingData) =>
-        // No facilities, treat as "Any"
-        goto(askPhysiotherapist).using(data)
+    staticData(rehabFacilityConfig) { data =>
+      val facilities =
+        data.rehabFacilities
+          .map(_.facilities.filter(_.locationId == data.cityId.id))
+          .getOrElse(Nil)
+      staticOptions(
+        staticOptions = Right(facilities),
+        applyId = facility => data.withFacility(facility)
+      )
+    }(requestNext = continueAfterFacility)
+
+  private def continueAfterFacility: Step =
+    process { data =>
+      if (data.hasAnyFacility) goto(askPhysiotherapist)
+      else goto(askAddAnotherFacility)
+    }
+
+  private def askAddAnotherFacility: Step =
+    ask { data =>
+      bot.sendMessage(
+        userId.source,
+        lang.selectedRehabFacilities(data),
+        inlineKeyboard =
+          createInlineKeyboard(
+            Seq(Button(lang.addAnotherClinic, Tags.AddAnotherFacility), Button(lang.continueBooking, Tags.Continue))
+          )
+      )
+    } onReply {
+      case Msg(CallbackCommand(Tags.AddAnotherFacility), _) =>
+        goto(selectFacility)
+      case Msg(CallbackCommand(Tags.Continue), _) =>
+        goto(askPhysiotherapist)
     }
 
   private def askPhysiotherapist: Step =
@@ -151,7 +166,10 @@ class RehabBook(
         case Right(Nil) =>
           goto(requestDateFrom).using(data)
         case Right(doctors) =>
-          val doctorItems = doctors.map(_.toIdName)
+          val facilityFilter = data.facilityFilter
+          val doctorItems = doctors
+            .filter(doc => facilityFilter.isEmpty || doc.facilityGroupIds.exists(ids => facilityFilter.exists(ids.contains)))
+            .map(_.toIdName)
           physiotherapistPager.restart()
           physiotherapistPager ! Right(new SimpleItemsProvider(doctorItems))
           bot.sendMessage(
@@ -185,6 +203,8 @@ class RehabBook(
       case Msg(cmd: Command, _) =>
         datePicker ! cmd
         stay()
+      case Msg(dateRange: DateRange, data: RehabBookingData) =>
+        goto(requestTimeFrom).using(data.copy(dateFrom = dateRange.from, dateTo = capDateTo(dateRange.from, dateRange.to)))
       case Msg(date: LocalDateTime, data: RehabBookingData) =>
         goto(requestDateTo).using(data.copy(dateFrom = date))
     }
@@ -200,9 +220,7 @@ class RehabBook(
         stay()
       case Msg(date: LocalDateTime, data: RehabBookingData) =>
         // Enforce MaxIntervalInDays = 13
-        val maxDate = data.dateFrom.plusDays(13)
-        val effectiveDate = if (date.isAfter(maxDate)) maxDate else date
-        goto(requestTimeFrom).using(data.copy(dateTo = effectiveDate))
+        goto(requestTimeFrom).using(data.copy(dateTo = capDateTo(data.dateFrom, date)))
     }
 
   private def requestTimeFrom: Step =
@@ -251,6 +269,7 @@ class RehabBook(
 
   private def requestTerm: Step =
     ask { data =>
+      val selectedFacilityIds = data.facilityFilter
       val availableTerms = apiService.getAvailableRehabTerms(
         userId.accountId,
         data.cityId.id,
@@ -261,9 +280,9 @@ class RehabBook(
         data.dateTo,
         data.timeFrom,
         data.timeTo,
-        Option(data.facilityId).flatMap(f => f.optionalId),
+        data.singleFacilityId,
         Option(data.physiotherapistId).flatMap(d => d.optionalId)
-      )
+      ).map(filterSelectedFacilities(_, selectedFacilityIds))
       termsPager.restart()
       termsPager ! availableTerms.map(new SimpleItemsProvider(_))
     } onReply {
@@ -320,7 +339,7 @@ class RehabBook(
         }
         val newData = data.copy(offset = defaultOffset)
         if (askOffset) goto(askMonitoringOffsetOption).using(newData)
-        else goto(askMonitoringAutobookOption).using(newData)
+        else goto(askMonitoringExclusionsOption).using(newData)
     }
 
   private def askMonitoringOffsetOption: Step =
@@ -332,9 +351,60 @@ class RehabBook(
       )
     } onReply {
       case Msg(TextCommand(IntString(offset)), data: RehabBookingData) =>
-        goto(askMonitoringAutobookOption).using(data.copy(offset = offset))
+        goto(askMonitoringExclusionsOption).using(data.copy(offset = offset))
+      case Msg(CallbackCommand(BooleanString(false)), _) =>
+        goto(askMonitoringExclusionsOption)
+    }
+
+  private def askMonitoringExclusionsOption: Step =
+    ask { _ =>
+      bot.sendMessage(
+        userId.source,
+        lang.addMonitoringExclusions,
+        inlineKeyboard = createInlineKeyboard(Seq(Button(lang.no, Tags.No), Button(lang.yes, Tags.Yes)))
+      )
+    } onReply {
+      case Msg(CallbackCommand(BooleanString(true)), _) =>
+        goto(askExcludedWeekdays)
       case Msg(CallbackCommand(BooleanString(false)), _) =>
         goto(askMonitoringAutobookOption)
+    }
+
+  private def askExcludedWeekdays: Step =
+    ask { data =>
+      bot.sendMessage(
+        userId.source,
+        lang.chooseExcludedWeekdays(data.excludedWeekdays),
+        inlineKeyboard = weekdayKeyboard(data.excludedWeekdays)
+      )
+    } onReply {
+      case Msg(CallbackCommand(Tags.Done), _) =>
+        goto(askExcludedDates)
+      case Msg(CallbackCommand(WeekdayTag(dayOfWeek)), data: RehabBookingData) =>
+        val weekdays =
+          if (data.excludedWeekdays.contains(dayOfWeek)) data.excludedWeekdays - dayOfWeek
+          else data.excludedWeekdays + dayOfWeek
+        goto(askExcludedWeekdays).using(data.copy(excludedWeekdays = weekdays))
+    }
+
+  private def askExcludedDates: Step =
+    ask { _ =>
+      bot.sendMessage(
+        userId.source,
+        lang.pleaseEnterExcludedDates,
+        inlineKeyboard = createInlineKeyboard(Seq(Button(lang.no, Tags.No)))
+      )
+    } onReply {
+      case Msg(CallbackCommand(BooleanString(false)), _) =>
+        goto(askMonitoringAutobookOption)
+      case Msg(TextCommand(text), data: RehabBookingData) =>
+        parseExcludedDates(text, data.dateFrom.toLocalDate) match {
+          case Left(error) =>
+            bot.sendMessage(userId.source, lang.unableToParseExcludedDates(error))
+            stay()
+          case Right(dates) =>
+            goto(askMonitoringAutobookOption).using(data.copy(excludedDates = dates.toSet))
+        }
     }
 
   private def askMonitoringAutobookOption: Step =
@@ -435,12 +505,84 @@ class RehabBook(
         end()
     }
 
+  private def staticData(staticDataConfig: => StaticDataConfig)(
+    functions: RehabBookingData => Step => MessageProcessorFn
+  )(requestNext: Step)(implicit functionName: sourcecode.Name): Step = {
+    ask { _ =>
+      staticData.restart()
+      staticData ! staticDataConfig
+    } onReply { case msg @ Msg(_, data: RehabBookingData) =>
+      val fn = functions(data)(requestNext)
+      fn(msg)
+    }
+  }
+
+  private def staticOptions[T <: Identified](
+    staticOptions: => Either[Throwable, List[T]],
+    applyId: IdName => RehabBookingData
+  ): Step => MessageProcessorFn = { nextStep =>
+    {
+      case Msg(cmd: Command, _) =>
+        staticData ! cmd
+        stay()
+      case Msg(LatestOptions, _) =>
+        staticData ! LatestOptions(Nil)
+        stay()
+      case Msg(FindOptions(searchText), _) =>
+        staticData ! FoundOptions(staticOptions.map(_.filter(_.name.toLowerCase.contains(searchText))))
+        stay()
+      case Msg(id: IdName, _) =>
+        goto(nextStep).using(applyId(id))
+    }
+  }
+
+  private def weekdayKeyboard(excludedWeekdays: Set[DayOfWeek]) = {
+    val weekdays = DayOfWeek.values.toSeq
+    val buttons = weekdays.map { day =>
+      val label = s"${if (excludedWeekdays.contains(day)) "✅ " else ""}${lang.weekdayName(day)}"
+      Button(label, Tags.WeekdayPrefix + day.getValue)
+    }
+    createInlineKeyboard(buttons :+ Button(lang.done, Tags.Done), columns = 2)
+  }
+
+  private def parseExcludedDates(text: String, dateFrom: LocalDate): Either[String, Seq[LocalDate]] = {
+    val parts = text.split("[,;\\s]+").map(_.trim).filter(_.nonEmpty).toSeq
+    val parsed = parts.map(parseExcludedDate(_, dateFrom))
+    parsed.collectFirst { case Left(value) => value } match {
+      case Some(error) => Left(error)
+      case None        => Right(parsed.collect { case Right(date) => date })
+    }
+  }
+
+  private def parseExcludedDate(text: String, dateFrom: LocalDate): Either[String, LocalDate] = {
+    val fullDate = Try(LocalDate.parse(text)).toOption
+    val dayMonth = Try {
+      val parsed = MonthDay.parse(text, DateTimeFormatter.ofPattern("dd-MM"))
+      val candidate = parsed.atYear(dateFrom.getYear)
+      if (candidate.isBefore(dateFrom)) candidate.plusYears(1) else candidate
+    }.toOption
+
+    fullDate.orElse(dayMonth).toRight(text)
+  }
+
+  private def filterSelectedFacilities(terms: List[TermExt], facilityIds: Seq[Long]): List[TermExt] =
+    if (facilityIds.size <= 1) terms
+    else terms.filter(term => facilityIds.contains(term.term.clinicGroupId))
+
+  private def capDateTo(dateFrom: LocalDateTime, dateTo: LocalDateTime): LocalDateTime = {
+    val maxDate = dateFrom.plusDays(13)
+    if (dateTo.isAfter(maxDate)) maxDate else dateTo
+  }
+
+  private def rehabCityConfig = StaticDataConfig(lang.city, "wro", "Wrocław", isAnyAllowed = false)
+
+  private def rehabFacilityConfig = StaticDataConfig(lang.clinic, "swob", "Swobodna 1", isAnyAllowed = true)
+
   beforeDestroy {
     datePicker.destroy()
     timePicker.destroy()
     referralPager.destroy()
-    locationPager.destroy()
-    facilityPager.destroy()
+    staticData.destroy()
     physiotherapistPager.destroy()
     termsPager.destroy()
   }
@@ -458,6 +600,7 @@ object RehabBook {
     serviceVariantName: String = "",
     cityId: IdName = null,
     facilityId: IdName = null,
+    facilityIds: Seq[IdName] = Seq(),
     physiotherapistId: IdName = null,
     rehabFacilities: Option[RehabFacilitiesResponse] = None,
     dateFrom: LocalDateTime = LocalDateTime.now(),
@@ -470,8 +613,36 @@ object RehabBook {
     remainingProcedures: Int = 0,
     offset: Int = 0,
     autobook: Boolean = false,
-    rebookIfExists: Boolean = false
-  )
+    rebookIfExists: Boolean = false,
+    excludedWeekdays: Set[DayOfWeek] = Set.empty,
+    excludedDates: Set[LocalDate] = Set.empty
+  ) {
+    def selectedFacilities: Seq[IdName] = {
+      if (facilityIds.nonEmpty) facilityIds
+      else Option(facilityId).toSeq
+    }
+
+    def facilityOptions: Seq[Option[Long]] = selectedFacilities.map(_.optionalId) match {
+      case Nil => Seq(None)
+      case xs  => xs
+    }
+
+    def facilityFilter: Seq[Long] = facilityOptions.flatten.distinct
+
+    def singleFacilityId: Option[Long] = {
+      val selected = facilityOptions.distinct
+      if (selected.size == 1) selected.head else None
+    }
+
+    def hasAnyFacility: Boolean = facilityOptions.exists(_.isEmpty)
+
+    def withFacility(facility: IdName): RehabBookingData = {
+      val updatedFacilities =
+        if (facility.optionalId.isEmpty) Seq(facility)
+        else (selectedFacilities.filter(_.optionalId.nonEmpty) :+ facility).distinctBy(_.id)
+      copy(facilityId = updatedFacilities.head, facilityIds = updatedFacilities)
+    }
+  }
 
   object Tags {
     val Cancel = "cancel"
@@ -484,6 +655,19 @@ object RehabBook {
     val BookByApplication = "true"
     val Yes = "true"
     val No = "false"
+    val AddAnotherFacility = "add_another_facility"
+    val Continue = "continue"
+    val Done = "done"
+    val WeekdayPrefix = "weekday_"
+  }
+
+  object WeekdayTag {
+    def unapply(tag: String): Option[DayOfWeek] =
+      tag.stripPrefix(Tags.WeekdayPrefix) match {
+        case value if tag.startsWith(Tags.WeekdayPrefix) =>
+          Try(DayOfWeek.of(value.toInt)).toOption
+        case _ => None
+      }
   }
 }
 

--- a/server/src/main/scala/com/lbs/server/conversation/RehabBook.scala
+++ b/server/src/main/scala/com/lbs/server/conversation/RehabBook.scala
@@ -204,9 +204,18 @@ class RehabBook(
         datePicker ! cmd
         stay()
       case Msg(dateRange: DateRange, data: RehabBookingData) =>
-        goto(requestTimeFrom).using(data.copy(dateFrom = dateRange.from, dateTo = capDateTo(dateRange.from, dateRange.to)))
+        goto(askExcludedWeekdays).using(data.copy(
+          dateFrom = dateRange.from,
+          dateTo = capDateTo(dateRange.from, dateRange.to),
+          excludedWeekdays = Set.empty,
+          excludedDates = Set.empty
+        ))
       case Msg(date: LocalDateTime, data: RehabBookingData) =>
-        goto(requestDateTo).using(data.copy(dateFrom = date))
+        goto(requestDateTo).using(data.copy(
+          dateFrom = date,
+          excludedWeekdays = Set.empty,
+          excludedDates = Set.empty
+        ))
     }
 
   private def requestDateTo: Step =
@@ -220,7 +229,7 @@ class RehabBook(
         stay()
       case Msg(date: LocalDateTime, data: RehabBookingData) =>
         // Enforce MaxIntervalInDays = 13
-        goto(requestTimeFrom).using(data.copy(dateTo = capDateTo(data.dateFrom, date)))
+        goto(askExcludedWeekdays).using(data.copy(dateTo = capDateTo(data.dateFrom, date)))
     }
 
   private def requestTimeFrom: Step =
@@ -263,7 +272,9 @@ class RehabBook(
       case Msg(CallbackCommand(Tags.ModifyDate), data: RehabBookingData) =>
         goto(requestDateFrom).using(data.copy(
           dateFrom = LocalDateTime.now(),
-          dateTo = LocalDateTime.now().plusDays(1L)
+          dateTo = LocalDateTime.now().plusDays(1L),
+          excludedWeekdays = Set.empty,
+          excludedDates = Set.empty
         ))
     }
 
@@ -283,6 +294,9 @@ class RehabBook(
         data.singleFacilityId,
         Option(data.physiotherapistId).flatMap(d => d.optionalId)
       ).map(filterSelectedFacilities(_, selectedFacilityIds))
+        .map(_.filterNot(term => data.excludedWeekdays.contains(term.term.dateTimeFrom.get.getDayOfWeek)))
+        .map(_.filterNot(term => data.excludedDates.contains(term.term.dateTimeFrom.get.toLocalDate)))
+        .map(_.sortBy(_.term.dateTimeFrom.get))
       termsPager.restart()
       termsPager ! availableTerms.map(new SimpleItemsProvider(_))
     } onReply {
@@ -329,7 +343,9 @@ class RehabBook(
       case Msg(CallbackCommand(Tags.ModifyDate), data: RehabBookingData) =>
         goto(requestDateFrom).using(data.copy(
           dateFrom = LocalDateTime.now(),
-          dateTo = LocalDateTime.now().plusDays(1L)
+          dateTo = LocalDateTime.now().plusDays(1L),
+          excludedWeekdays = Set.empty,
+          excludedDates = Set.empty
         ))
       case Msg(CallbackCommand(Tags.CreateMonitoring), data: RehabBookingData) =>
         val settingsMaybe = dataService.findSettings(userId.userId)
@@ -339,7 +355,7 @@ class RehabBook(
         }
         val newData = data.copy(offset = defaultOffset)
         if (askOffset) goto(askMonitoringOffsetOption).using(newData)
-        else goto(askMonitoringExclusionsOption).using(newData)
+        else goto(askMonitoringAutobookOption).using(newData)
     }
 
   private def askMonitoringOffsetOption: Step =
@@ -351,21 +367,7 @@ class RehabBook(
       )
     } onReply {
       case Msg(TextCommand(IntString(offset)), data: RehabBookingData) =>
-        goto(askMonitoringExclusionsOption).using(data.copy(offset = offset))
-      case Msg(CallbackCommand(BooleanString(false)), _) =>
-        goto(askMonitoringExclusionsOption)
-    }
-
-  private def askMonitoringExclusionsOption: Step =
-    ask { _ =>
-      bot.sendMessage(
-        userId.source,
-        lang.addMonitoringExclusions,
-        inlineKeyboard = createInlineKeyboard(Seq(Button(lang.no, Tags.No), Button(lang.yes, Tags.Yes)))
-      )
-    } onReply {
-      case Msg(CallbackCommand(BooleanString(true)), _) =>
-        goto(askExcludedWeekdays)
+        goto(askMonitoringAutobookOption).using(data.copy(offset = offset))
       case Msg(CallbackCommand(BooleanString(false)), _) =>
         goto(askMonitoringAutobookOption)
     }
@@ -396,14 +398,14 @@ class RehabBook(
       )
     } onReply {
       case Msg(CallbackCommand(BooleanString(false)), _) =>
-        goto(askMonitoringAutobookOption)
+        goto(requestTimeFrom)
       case Msg(TextCommand(text), data: RehabBookingData) =>
         parseExcludedDates(text, data.dateFrom.toLocalDate) match {
           case Left(error) =>
             bot.sendMessage(userId.source, lang.unableToParseExcludedDates(error))
             stay()
           case Right(dates) =>
-            goto(askMonitoringAutobookOption).using(data.copy(excludedDates = dates.toSet))
+            goto(requestTimeFrom).using(data.copy(excludedDates = dates.toSet))
         }
     }
 

--- a/server/src/main/scala/com/lbs/server/lang/En.scala
+++ b/server/src/main/scala/com/lbs/server/lang/En.scala
@@ -7,7 +7,8 @@ import com.lbs.server.conversation.StaticData.StaticDataConfig
 import com.lbs.server.repository.model.Monitoring
 import com.lbs.server.util.DateTimeUtil.*
 
-import java.time.{LocalDateTime, LocalTime}
+import java.time.{DayOfWeek, LocalDate, LocalDateTime, LocalTime}
+import java.time.format.TextStyle
 import java.util.Locale
 
 object En extends Lang {
@@ -50,10 +51,24 @@ object En extends Lang {
        |""".stripMargin
 
   override def chooseDateFrom(exampleDate: LocalDateTime): String =
-    s"<b>➡</b> Please choose date from or write it manually using format dd-MM, e.g. ${formatDateShort(exampleDate)}"
+    s"<b>➡</b> Please choose a date, quick range, or type a range, e.g. ${formatDateShort(exampleDate)} ${formatDateShort(exampleDate.plusDays(7))}"
 
   override def chooseDateTo(exampleDate: LocalDateTime): String =
     s"<b>➡</b> Please choose a date to or write it manually using format dd-MM, e.g. ${formatDateShort(exampleDate)}"
+
+  override def quickRangeToday: String = "Today"
+
+  override def quickRangeTomorrow: String = "Tomorrow"
+
+  override def quickRangeNext7Days: String = "Next 7 days"
+
+  override def quickRangeNext14Days: String = "Next 14 days"
+
+  override def dateRangeIs(dateFrom: LocalDateTime, dateTo: LocalDateTime): String =
+    s"📅 Date range is ${formatDate(dateFrom, locale)} -> ${formatDate(dateTo, locale)}"
+
+  override def incorrectDateFormat: String =
+    "Incorrect date. Use dd-MM, YYYY-MM-DD, or a range like 10-06 20-06"
 
   override def findTerms: String = "🔍 Find terms"
 
@@ -62,7 +77,7 @@ object En extends Lang {
   override def bookingSummary(bookingData: Book.BookingData): String =
     s"🦄 Ok! We are going to book the service <b>${bookingData.serviceId.name}</b>" +
       s" with the doctor chosen <b>${bookingData.doctorId.name}</b>" +
-      s" in <b>${bookingData.clinicId.name}</b> clinic" +
+      s" in <b>${bookingData.selectedClinics.map(_.name).mkString(", ")}</b> clinic" +
       s" of <b>${bookingData.cityId.name}</b> city." +
       s"\nDesired dates: <b>${formatDate(bookingData.dateFrom, locale)}</b> -> <b>${formatDate(bookingData.dateTo, locale)}</b>" +
       s"\nTime: <b>${formatTime(bookingData.timeFrom)} -> ${formatTime(bookingData.timeTo)}</b>" +
@@ -91,6 +106,49 @@ object En extends Lang {
   override def monitoringHasBeenCreated: String = "👍 Monitoring has been created! List of active /monitorings"
 
   override def unableToCreateMonitoring(reason: String): String = s"👎 Unable to create monitoring. Reason: $reason."
+
+  override def selectedClinics(bookingData: Book.BookingData): String =
+    s"""<b>➡</b> Selected clinics:
+       |<b>${bookingData.selectedClinics.map(_.name).mkString(", ")}</b>
+       |
+       |Do you want to add another clinic?""".stripMargin
+
+  override def selectedRehabFacilities(data: RehabBookingData): String =
+    s"""<b>➡</b> Selected rehabilitation facilities:
+       |<b>${data.selectedFacilities.map(_.name).mkString(", ")}</b>
+       |
+       |Do you want to add another facility?""".stripMargin
+
+  override def addAnotherClinic: String = "➕ Add another"
+
+  override def continueBooking: String = "Continue"
+
+  override def addMonitoringExclusions: String =
+    "<b>➡</b> Do you want to add excluded days for this monitoring?"
+
+  override def chooseExcludedWeekdays(excludedWeekdays: Set[DayOfWeek]): String =
+    s"""<b>➡</b> Choose weekdays to exclude.
+       |
+       |${excludedWeekdaysLabel(excludedWeekdays)}""".stripMargin
+
+  override def pleaseEnterExcludedDates: String =
+    "<b>➡</b> Enter exact dates to exclude, e.g. 2026-06-10, 15-06, or press No"
+
+  override def unableToParseExcludedDates(value: String): String =
+    s"Unable to parse date: $value. Use YYYY-MM-DD or DD-MM format."
+
+  override def done: String = "Done"
+
+  override def weekdayName(dayOfWeek: DayOfWeek): String =
+    dayOfWeek.getDisplayName(TextStyle.FULL, locale)
+
+  override def excludedWeekdaysLabel(excludedWeekdays: Set[DayOfWeek]): String =
+    if (excludedWeekdays.isEmpty) "Excluded weekdays: none"
+    else s"Excluded weekdays: ${excludedWeekdays.toSeq.sortBy(_.getValue).map(weekdayName).mkString(", ")}"
+
+  override def excludedDatesLabel(excludedDates: Set[LocalDate]): String =
+    if (excludedDates.isEmpty) "Excluded dates: none"
+    else s"Excluded dates: ${excludedDates.toSeq.sortBy(_.toString).mkString(", ")}"
 
   override def chooseTypeOfMonitoring: String = "<b>➡</b> Please choose the type of monitoring you want"
 
@@ -126,7 +184,9 @@ object En extends Lang {
        |⏱ <b>${formatTime(monitoring.timeFrom)}</b> -> <b>${formatTime(monitoring.timeTo)}</b>
        |${capitalize(doctor)}: ${monitoring.doctorName}
        |${capitalize(service)}: ${monitoring.serviceName}
-       |${capitalize(clinic)}: ${monitoring.clinicName}""".stripMargin
+       |${capitalize(clinic)}: ${monitoring.clinicDisplayName}
+       |${excludedWeekdaysLabel(monitoring.excludedWeekdaysSet)}
+       |${excludedDatesLabel(monitoring.excludedDatesSet)}""".stripMargin
 
   override def deactivated: String = "👍 Deactivated! List of active /monitorings"
 
@@ -244,8 +304,10 @@ object En extends Lang {
        |⏱ <b>${formatTime(monitoring.timeFrom)}</b> -> <b>${formatTime(monitoring.timeTo)}</b>
        |${capitalize(doctor)}: ${monitoring.doctorName}
        |${capitalize(service)}: ${monitoring.serviceName}
-       |${capitalize(clinic)}: ${monitoring.clinicName}
+       |${capitalize(clinic)}: ${monitoring.clinicDisplayName}
        |${capitalize(city)}: ${monitoring.cityName}
+       |${excludedWeekdaysLabel(monitoring.excludedWeekdaysSet)}
+       |${excludedDatesLabel(monitoring.excludedDatesSet)}
        |Type: ${if (monitoring.autobook) "Auto" else "Manual"}
        |Rebook existing reservation: ${if (monitoring.rebookIfExists) "Yes" else "No"}
        |<b>➡</b> /cancel_$index
@@ -257,8 +319,10 @@ object En extends Lang {
        |⏱ <b>${formatTime(monitoring.timeFrom)}</b> -> <b>${formatTime(monitoring.timeTo)}</b>
        |${capitalize(doctor)}: ${monitoring.doctorName}
        |${capitalize(service)}: ${monitoring.serviceName}
-       |${capitalize(clinic)}: ${monitoring.clinicName}
+       |${capitalize(clinic)}: ${monitoring.clinicDisplayName}
        |${capitalize(city)}: ${monitoring.cityName}
+       |${excludedWeekdaysLabel(monitoring.excludedWeekdaysSet)}
+       |${excludedDatesLabel(monitoring.excludedDatesSet)}
        |Type: ${if (monitoring.autobook) "Auto" else "Manual"}
        |<b>➡</b> /repeat_$index
        |
@@ -297,8 +361,10 @@ object En extends Lang {
        |⏱ <b>${formatTime(monitoring.timeFrom)}</b> -> <b>${formatTime(monitoring.timeTo)}</b>
        |${capitalize(doctor)}: ${monitoring.doctorName}
        |${capitalize(service)}: ${monitoring.serviceName}
-       |${capitalize(clinic)}: ${monitoring.clinicName}
+       |${capitalize(clinic)}: ${monitoring.clinicDisplayName}
        |${capitalize(city)}: ${monitoring.cityName}
+       |${excludedWeekdaysLabel(monitoring.excludedWeekdaysSet)}
+       |${excludedDatesLabel(monitoring.excludedDatesSet)}
        |
        |<b>➡</b> Create a new monitoring /book""".stripMargin
 
@@ -416,7 +482,7 @@ object En extends Lang {
     s"""🏥 <b>Rehabilitation booking</b>
        |Service: ${data.serviceVariantName}
        |City: ${data.cityId.name}
-       |Facility: ${if (data.facilityId != null) data.facilityId.name else "Any"}
+       |Facility: ${if (data.selectedFacilities.nonEmpty) data.selectedFacilities.map(_.name).mkString(", ") else "Any"}
        |Physiotherapist: ${if (data.physiotherapistId != null) data.physiotherapistId.name else "Any"}
        |Date: ${formatDate(data.dateFrom, locale)} — ${formatDate(data.dateTo, locale)}
        |Time: ${formatTime(data.timeFrom)} — ${formatTime(data.timeTo)}

--- a/server/src/main/scala/com/lbs/server/lang/En.scala
+++ b/server/src/main/scala/com/lbs/server/lang/En.scala
@@ -377,7 +377,7 @@ object En extends Lang {
        |${capitalize(clinic)}: ${term.term.clinic.getOrElse("")}
        |${capitalize(city)}: ${monitoring.cityName}""".stripMargin
 
-  override def maximumMonitoringsLimitExceeded: String = "Maximum monitorings per user is 10"
+  override def maximumMonitoringsLimitExceeded: String = "Maximum monitoring slots per user is 10"
 
   override def termIsOutdated: String =
     s"""❗️ Looks like the term is already booked by someone else

--- a/server/src/main/scala/com/lbs/server/lang/Lang.scala
+++ b/server/src/main/scala/com/lbs/server/lang/Lang.scala
@@ -6,7 +6,7 @@ import com.lbs.server.conversation.RehabBook.RehabBookingData
 import com.lbs.server.conversation.StaticData.StaticDataConfig
 import com.lbs.server.repository.model.Monitoring
 
-import java.time.{LocalDateTime, LocalTime}
+import java.time.{DayOfWeek, LocalDate, LocalDateTime, LocalTime}
 import java.util.Locale
 import scala.io.Source
 import scala.util.Try
@@ -57,6 +57,18 @@ trait Lang {
 
   def chooseDateTo(exampleDate: LocalDateTime): String
 
+  def quickRangeToday: String
+
+  def quickRangeTomorrow: String
+
+  def quickRangeNext7Days: String
+
+  def quickRangeNext14Days: String
+
+  def dateRangeIs(dateFrom: LocalDateTime, dateTo: LocalDateTime): String
+
+  def incorrectDateFormat: String
+
   def chooseTimeFrom(exampleTime: LocalTime): String
 
   def chooseTimeTo(exampleTime: LocalTime): String
@@ -84,6 +96,30 @@ trait Lang {
   def monitoringHasBeenCreated: String
 
   def unableToCreateMonitoring(reason: String): String
+
+  def selectedClinics(bookingData: BookingData): String
+
+  def selectedRehabFacilities(data: RehabBookingData): String
+
+  def addAnotherClinic: String
+
+  def continueBooking: String
+
+  def addMonitoringExclusions: String
+
+  def chooseExcludedWeekdays(excludedWeekdays: Set[DayOfWeek]): String
+
+  def pleaseEnterExcludedDates: String
+
+  def unableToParseExcludedDates(value: String): String
+
+  def done: String
+
+  def weekdayName(dayOfWeek: DayOfWeek): String
+
+  def excludedWeekdaysLabel(excludedWeekdays: Set[DayOfWeek]): String
+
+  def excludedDatesLabel(excludedDates: Set[LocalDate]): String
 
   def chooseTypeOfMonitoring: String
 

--- a/server/src/main/scala/com/lbs/server/lang/Pl.scala
+++ b/server/src/main/scala/com/lbs/server/lang/Pl.scala
@@ -7,7 +7,8 @@ import com.lbs.server.conversation.StaticData.StaticDataConfig
 import com.lbs.server.repository.model.Monitoring
 import com.lbs.server.util.DateTimeUtil.*
 
-import java.time.{LocalDateTime, LocalTime}
+import java.time.{DayOfWeek, LocalDate, LocalDateTime, LocalTime}
+import java.time.format.TextStyle
 import java.util.Locale
 
 object Pl extends Lang {
@@ -50,10 +51,24 @@ object Pl extends Lang {
        |""".stripMargin
 
   override def chooseDateFrom(exampleDate: LocalDateTime): String =
-    s"<b>➡</b> Wybierz datę albo zapisz ją w formacie dd-MM, np. ${formatDateShort(exampleDate)}"
+    s"<b>➡</b> Wybierz datę, szybki zakres albo wpisz zakres, np. ${formatDateShort(exampleDate)} ${formatDateShort(exampleDate.plusDays(7))}"
 
   override def chooseDateTo(exampleDate: LocalDateTime): String =
     s"<b>➡</b> Wybierz datę albo zapisz ją w formacie dd-MM, np. ${formatDateShort(exampleDate)}"
+
+  override def quickRangeToday: String = "Dzisiaj"
+
+  override def quickRangeTomorrow: String = "Jutro"
+
+  override def quickRangeNext7Days: String = "Najbliższe 7 dni"
+
+  override def quickRangeNext14Days: String = "Najbliższe 14 dni"
+
+  override def dateRangeIs(dateFrom: LocalDateTime, dateTo: LocalDateTime): String =
+    s"📅 Zakres dat: ${formatDate(dateFrom, locale)} -> ${formatDate(dateTo, locale)}"
+
+  override def incorrectDateFormat: String =
+    "Niepoprawna data. Użyj formatu dd-MM, YYYY-MM-DD albo zakresu, np. 10-06 20-06"
 
   override def findTerms: String = "🔍 Szukaj terminów"
 
@@ -62,7 +77,7 @@ object Pl extends Lang {
   override def bookingSummary(bookingData: Book.BookingData): String =
     s"🦄 Ok! Zarezerwujemy wizytę typu <b>${bookingData.serviceId.name}</b>" +
       s" z lekarzem: <b>${bookingData.doctorId.name}</b>" +
-      s" w klinice: <b>${bookingData.clinicId.name}</b>" +
+      s" w klinice: <b>${bookingData.selectedClinics.map(_.name).mkString(", ")}</b>" +
       s" w mieście <b>${bookingData.cityId.name}</b>." +
       s"\nWybrane daty: <b>${formatDate(bookingData.dateFrom, locale)}</b> -> <b>${formatDate(bookingData.dateTo, locale)}</b>" +
       s" w godzinach: <b>${formatTime(bookingData.timeFrom)} -> ${formatTime(bookingData.timeTo)}</b>" +
@@ -93,6 +108,49 @@ object Pl extends Lang {
 
   override def unableToCreateMonitoring(reason: String): String =
     s"👎 Nie udało się stworzyć monitoringu. Powód: $reason."
+
+  override def selectedClinics(bookingData: Book.BookingData): String =
+    s"""<b>➡</b> Wybrane kliniki:
+       |<b>${bookingData.selectedClinics.map(_.name).mkString(", ")}</b>
+       |
+       |Czy chcesz dodać kolejną klinikę?""".stripMargin
+
+  override def selectedRehabFacilities(data: RehabBookingData): String =
+    s"""<b>➡</b> Wybrane placówki rehabilitacyjne:
+       |<b>${data.selectedFacilities.map(_.name).mkString(", ")}</b>
+       |
+       |Czy chcesz dodać kolejną placówkę?""".stripMargin
+
+  override def addAnotherClinic: String = "➕ Dodaj kolejną"
+
+  override def continueBooking: String = "Dalej"
+
+  override def addMonitoringExclusions: String =
+    "<b>➡</b> Czy chcesz dodać wykluczenia dni dla monitoringu?"
+
+  override def chooseExcludedWeekdays(excludedWeekdays: Set[DayOfWeek]): String =
+    s"""<b>➡</b> Wybierz dni tygodnia do wykluczenia.
+       |
+       |${excludedWeekdaysLabel(excludedWeekdays)}""".stripMargin
+
+  override def pleaseEnterExcludedDates: String =
+    "<b>➡</b> Podaj konkretne daty do wykluczenia, np. 2026-06-10, 15-06, albo kliknij Nie"
+
+  override def unableToParseExcludedDates(value: String): String =
+    s"Nie udało się rozpoznać daty: $value. Użyj formatu YYYY-MM-DD albo DD-MM."
+
+  override def done: String = "Gotowe"
+
+  override def weekdayName(dayOfWeek: DayOfWeek): String =
+    dayOfWeek.getDisplayName(TextStyle.FULL, locale)
+
+  override def excludedWeekdaysLabel(excludedWeekdays: Set[DayOfWeek]): String =
+    if (excludedWeekdays.isEmpty) "Wykluczone dni tygodnia: brak"
+    else s"Wykluczone dni tygodnia: ${excludedWeekdays.toSeq.sortBy(_.getValue).map(weekdayName).mkString(", ")}"
+
+  override def excludedDatesLabel(excludedDates: Set[LocalDate]): String =
+    if (excludedDates.isEmpty) "Wykluczone daty: brak"
+    else s"Wykluczone daty: ${excludedDates.toSeq.sortBy(_.toString).mkString(", ")}"
 
   override def chooseTypeOfMonitoring: String = "<b>➡</b> Wybierz typ monitoringu"
 
@@ -128,7 +186,9 @@ object Pl extends Lang {
        |⏱ <b>${formatTime(monitoring.timeFrom)}</b> -> <b>${formatTime(monitoring.timeTo)}</b>
        |${capitalize(doctor)}: ${monitoring.doctorName}
        |${capitalize(service)}: ${monitoring.serviceName}
-       |${capitalize(clinic)}: ${monitoring.clinicName}""".stripMargin
+       |${capitalize(clinic)}: ${monitoring.clinicDisplayName}
+       |${excludedWeekdaysLabel(monitoring.excludedWeekdaysSet)}
+       |${excludedDatesLabel(monitoring.excludedDatesSet)}""".stripMargin
 
   override def deactivated: String = "👍 Wyłączony! Sprawdź aktywne monitoringi przez /monitorings"
 
@@ -246,8 +306,10 @@ object Pl extends Lang {
        |⏱ <b>${formatTime(monitoring.timeFrom)}</b> -> <b>${formatTime(monitoring.timeTo)}</b>
        |${capitalize(doctor)}: ${monitoring.doctorName}
        |${capitalize(service)}: ${monitoring.serviceName}
-       |${capitalize(clinic)}: ${monitoring.clinicName}
+       |${capitalize(clinic)}: ${monitoring.clinicDisplayName}
        |${capitalize(city)}: ${monitoring.cityName}
+       |${excludedWeekdaysLabel(monitoring.excludedWeekdaysSet)}
+       |${excludedDatesLabel(monitoring.excludedDatesSet)}
        |Sposób rejestracji: ${if (monitoring.autobook) "Automatyczny" else "Ręczny"}
        |Nadpisz istniejącą wizytę: ${if (monitoring.rebookIfExists) "Tak" else "Nie"}
        |<b>➡</b> /cancel_$index
@@ -259,8 +321,10 @@ object Pl extends Lang {
        |⏱ <b>${formatTime(monitoring.timeFrom)}</b> -> <b>${formatTime(monitoring.timeTo)}</b>
        |${capitalize(doctor)}: ${monitoring.doctorName}
        |${capitalize(service)}: ${monitoring.serviceName}
-       |${capitalize(clinic)}: ${monitoring.clinicName}
+       |${capitalize(clinic)}: ${monitoring.clinicDisplayName}
        |${capitalize(city)}: ${monitoring.cityName}
+       |${excludedWeekdaysLabel(monitoring.excludedWeekdaysSet)}
+       |${excludedDatesLabel(monitoring.excludedDatesSet)}
        |Sposób rejestracji: ${if (monitoring.autobook) "Automatyczny" else "Ręczny"}
        |<b>➡</b> /repeat_$index
        |
@@ -299,8 +363,10 @@ object Pl extends Lang {
        |⏱ <b>${formatTime(monitoring.timeFrom)}</b> -> <b>${formatTime(monitoring.timeTo)}</b>
        |${capitalize(doctor)}: ${monitoring.doctorName}
        |${capitalize(service)}: ${monitoring.serviceName}
-       |${capitalize(clinic)}: ${monitoring.clinicName}
+       |${capitalize(clinic)}: ${monitoring.clinicDisplayName}
        |${capitalize(city)}: ${monitoring.cityName}
+       |${excludedWeekdaysLabel(monitoring.excludedWeekdaysSet)}
+       |${excludedDatesLabel(monitoring.excludedDatesSet)}
        |
        |<b>➡</b> Stwórz nowy monitoring przez /book""".stripMargin
 
@@ -418,7 +484,7 @@ object Pl extends Lang {
     s"""🏥 <b>Rezerwacja rehabilitacji</b>
        |Usługa: ${data.serviceVariantName}
        |Miasto: ${data.cityId.name}
-       |Placówka: ${if (data.facilityId != null) data.facilityId.name else "Jakikolwiek"}
+       |Placówka: ${if (data.selectedFacilities.nonEmpty) data.selectedFacilities.map(_.name).mkString(", ") else "Jakakolwiek"}
        |Fizjoterapeuta: ${if (data.physiotherapistId != null) data.physiotherapistId.name else "Jakikolwiek"}
        |Data: ${formatDate(data.dateFrom, locale)} — ${formatDate(data.dateTo, locale)}
        |Godziny: ${formatTime(data.timeFrom)} — ${formatTime(data.timeTo)}

--- a/server/src/main/scala/com/lbs/server/lang/Pl.scala
+++ b/server/src/main/scala/com/lbs/server/lang/Pl.scala
@@ -379,7 +379,7 @@ object Pl extends Lang {
        |${capitalize(clinic)}: ${term.term.clinic.getOrElse("")}
        |${capitalize(city)}: ${monitoring.cityName}""".stripMargin
 
-  override def maximumMonitoringsLimitExceeded: String = "Maksymalna liczba monitoringów uzytkownika to 10"
+  override def maximumMonitoringsLimitExceeded: String = "Maksymalna liczba slotów monitoringu uzytkownika to 10"
 
   override def termIsOutdated: String =
     s"""❗️ Wygląda na to, ze ten termin został już zarezewowany!

--- a/server/src/main/scala/com/lbs/server/lang/Ua.scala
+++ b/server/src/main/scala/com/lbs/server/lang/Ua.scala
@@ -7,7 +7,8 @@ import com.lbs.server.conversation.StaticData.StaticDataConfig
 import com.lbs.server.repository.model.Monitoring
 import com.lbs.server.util.DateTimeUtil.*
 
-import java.time.{LocalDateTime, LocalTime}
+import java.time.{DayOfWeek, LocalDate, LocalDateTime, LocalTime}
+import java.time.format.TextStyle
 import java.util.Locale
 
 object Ua extends Lang {
@@ -50,10 +51,24 @@ object Ua extends Lang {
        |""".stripMargin
 
   override def chooseDateFrom(exampleDate: LocalDateTime): String =
-    s"<b>➡</b> Будь ласка, виберіть початкову дату або введіть її, використовуючи формат dd-MM, наприклад ${formatDateShort(exampleDate)}"
+    s"<b>➡</b> Виберіть дату, швидкий діапазон або введіть діапазон, наприклад ${formatDateShort(exampleDate)} ${formatDateShort(exampleDate.plusDays(7))}"
 
   override def chooseDateTo(exampleDate: LocalDateTime): String =
     s"<b>➡</b> Будь ласка, виберіть кінцеву дату або введіть її, використовуючи формат dd-MM, наприклад ${formatDateShort(exampleDate)}"
+
+  override def quickRangeToday: String = "Сьогодні"
+
+  override def quickRangeTomorrow: String = "Завтра"
+
+  override def quickRangeNext7Days: String = "Наступні 7 днів"
+
+  override def quickRangeNext14Days: String = "Наступні 14 днів"
+
+  override def dateRangeIs(dateFrom: LocalDateTime, dateTo: LocalDateTime): String =
+    s"📅 Діапазон дат: ${formatDate(dateFrom, locale)} -> ${formatDate(dateTo, locale)}"
+
+  override def incorrectDateFormat: String =
+    "Неправильна дата. Використовуйте dd-MM, YYYY-MM-DD або діапазон, наприклад 10-06 20-06"
 
   override def findTerms: String = "🔍 Знайти терміни"
 
@@ -62,7 +77,7 @@ object Ua extends Lang {
   override def bookingSummary(bookingData: Book.BookingData): String =
     s"🦄 Супер! Ми збираємося зарезервувати послугу <b>${bookingData.serviceId.name}</b>" +
       s" з обраним лікарем <b>${bookingData.doctorId.name}</b>" +
-      s" в <b>${bookingData.clinicId.name}</b> клініці" +
+      s" в <b>${bookingData.selectedClinics.map(_.name).mkString(", ")}</b> клініці" +
       s" міста <b>${bookingData.cityId.name}</b>." +
       s"\nБажані дати: <b>${formatDate(bookingData.dateFrom, locale)}</b> -> <b>${formatDate(bookingData.dateTo, locale)}</b>" +
       s"\nЧас: <b>${formatTime(bookingData.timeFrom)}</b> -> <b>${formatTime(bookingData.timeTo)}</b>" +
@@ -92,6 +107,49 @@ object Ua extends Lang {
 
   override def unableToCreateMonitoring(reason: String): String =
     s"👎 Не вдається створити моніторинг. Причина: $reason."
+
+  override def selectedClinics(bookingData: Book.BookingData): String =
+    s"""<b>➡</b> Вибрані клініки:
+       |<b>${bookingData.selectedClinics.map(_.name).mkString(", ")}</b>
+       |
+       |Додати ще одну клініку?""".stripMargin
+
+  override def selectedRehabFacilities(data: RehabBookingData): String =
+    s"""<b>➡</b> Вибрані реабілітаційні клініки:
+       |<b>${data.selectedFacilities.map(_.name).mkString(", ")}</b>
+       |
+       |Додати ще одну клініку?""".stripMargin
+
+  override def addAnotherClinic: String = "➕ Додати ще"
+
+  override def continueBooking: String = "Далі"
+
+  override def addMonitoringExclusions: String =
+    "<b>➡</b> Додати виключені дні для цього моніторингу?"
+
+  override def chooseExcludedWeekdays(excludedWeekdays: Set[DayOfWeek]): String =
+    s"""<b>➡</b> Виберіть дні тижня для виключення.
+       |
+       |${excludedWeekdaysLabel(excludedWeekdays)}""".stripMargin
+
+  override def pleaseEnterExcludedDates: String =
+    "<b>➡</b> Введіть конкретні дати для виключення, наприклад 2026-06-10, 15-06, або натисніть Ні"
+
+  override def unableToParseExcludedDates(value: String): String =
+    s"Не вдалося розпізнати дату: $value. Використайте формат YYYY-MM-DD або DD-MM."
+
+  override def done: String = "Готово"
+
+  override def weekdayName(dayOfWeek: DayOfWeek): String =
+    dayOfWeek.getDisplayName(TextStyle.FULL, locale)
+
+  override def excludedWeekdaysLabel(excludedWeekdays: Set[DayOfWeek]): String =
+    if (excludedWeekdays.isEmpty) "Виключені дні тижня: немає"
+    else s"Виключені дні тижня: ${excludedWeekdays.toSeq.sortBy(_.getValue).map(weekdayName).mkString(", ")}"
+
+  override def excludedDatesLabel(excludedDates: Set[LocalDate]): String =
+    if (excludedDates.isEmpty) "Виключені дати: немає"
+    else s"Виключені дати: ${excludedDates.toSeq.sortBy(_.toString).mkString(", ")}"
 
   override def chooseTypeOfMonitoring: String = "<b>➡</b> Будь ласка, виберіть тип моніторингу"
 
@@ -127,7 +185,9 @@ object Ua extends Lang {
        |⏱ <b>${formatTime(monitoring.timeFrom)}</b> -> <b>${formatTime(monitoring.timeTo)}</b>
        |${capitalize(doctor)}: ${monitoring.doctorName}
        |${capitalize(service)}: ${monitoring.serviceName}
-       |${capitalize(clinic)}: ${monitoring.clinicName}""".stripMargin
+       |${capitalize(clinic)}: ${monitoring.clinicDisplayName}
+       |${excludedWeekdaysLabel(monitoring.excludedWeekdaysSet)}
+       |${excludedDatesLabel(monitoring.excludedDatesSet)}""".stripMargin
 
   override def deactivated: String = "👍 Деактивовано! Список активних /monitorings"
 
@@ -244,8 +304,10 @@ object Ua extends Lang {
        |⏱ <b>${formatTime(monitoring.timeFrom)}</b> -> <b>${formatTime(monitoring.timeTo)}</b>
        |${capitalize(doctor)}: ${monitoring.doctorName}
        |${capitalize(service)}: ${monitoring.serviceName}
-       |${capitalize(clinic)}: ${monitoring.clinicName}
+       |${capitalize(clinic)}: ${monitoring.clinicDisplayName}
        |${capitalize(city)}: ${monitoring.cityName}
+       |${excludedWeekdaysLabel(monitoring.excludedWeekdaysSet)}
+       |${excludedDatesLabel(monitoring.excludedDatesSet)}
        |Тип: ${if (monitoring.autobook) "Автоматичний" else "Ручний"}
        |Оновити наявне бронювання: ${if (monitoring.rebookIfExists) "Так" else "Ні"}
        |<b>➡</b> /cancel_$index
@@ -257,8 +319,10 @@ object Ua extends Lang {
        |⏱ <b>${formatTime(monitoring.timeFrom)}</b> -> <b>${formatTime(monitoring.timeTo)}</b>
        |${capitalize(doctor)}: ${monitoring.doctorName}
        |${capitalize(service)}: ${monitoring.serviceName}
-       |${capitalize(clinic)}: ${monitoring.clinicName}
+       |${capitalize(clinic)}: ${monitoring.clinicDisplayName}
        |${capitalize(city)}: ${monitoring.cityName}
+       |${excludedWeekdaysLabel(monitoring.excludedWeekdaysSet)}
+       |${excludedDatesLabel(monitoring.excludedDatesSet)}
        |Тип: ${if (monitoring.autobook) "Автоматичний" else "Ручний"}
        |<b>➡</b> /repeat_$index
        |
@@ -297,8 +361,10 @@ object Ua extends Lang {
        |⏱ <b>${formatTime(monitoring.timeFrom)}</b> -> <b>${formatTime(monitoring.timeTo)}</b>
        |${capitalize(doctor)}: ${monitoring.doctorName}
        |${capitalize(service)}: ${monitoring.serviceName}
-       |${capitalize(clinic)}: ${monitoring.clinicName}
+       |${capitalize(clinic)}: ${monitoring.clinicDisplayName}
        |${capitalize(city)}: ${monitoring.cityName}
+       |${excludedWeekdaysLabel(monitoring.excludedWeekdaysSet)}
+       |${excludedDatesLabel(monitoring.excludedDatesSet)}
        |
        |<b>➡</b> Створити новий моніторінг /book""".stripMargin
 
@@ -417,7 +483,7 @@ object Ua extends Lang {
     s"""🏥 <b>Резервація реабілітації</b>
        |Послуга: ${data.serviceVariantName}
        |Місто: ${data.cityId.name}
-       |Заклад: ${if (data.facilityId != null) data.facilityId.name else "Будь-який"}
+       |Заклад: ${if (data.selectedFacilities.nonEmpty) data.selectedFacilities.map(_.name).mkString(", ") else "Будь-який"}
        |Фізіотерапевт: ${if (data.physiotherapistId != null) data.physiotherapistId.name else "Будь-який"}
        |Дата: ${formatDate(data.dateFrom, locale)} — ${formatDate(data.dateTo, locale)}
        |Час: ${formatTime(data.timeFrom)} — ${formatTime(data.timeTo)}

--- a/server/src/main/scala/com/lbs/server/lang/Ua.scala
+++ b/server/src/main/scala/com/lbs/server/lang/Ua.scala
@@ -377,7 +377,7 @@ object Ua extends Lang {
        |${capitalize(clinic)}: ${term.term.clinic.getOrElse("")}
        |${capitalize(city)}: ${monitoring.cityName}""".stripMargin
 
-  override def maximumMonitoringsLimitExceeded: String = "Максимальна кількість моніторінгів 10"
+  override def maximumMonitoringsLimitExceeded: String = "Максимальна кількість слотів моніторингу 10"
 
   override def termIsOutdated: String =
     s"""❗️ Схоже, що термін вже не є доступним

--- a/server/src/main/scala/com/lbs/server/repository/model/Monitoring.scala
+++ b/server/src/main/scala/com/lbs/server/repository/model/Monitoring.scala
@@ -2,7 +2,7 @@ package com.lbs.server.repository.model
 
 import jakarta.persistence.{Access, AccessType, Column, Entity}
 
-import java.time.{LocalTime, ZonedDateTime}
+import java.time.{DayOfWeek, LocalDate, LocalTime, ZonedDateTime}
 import scala.beans.BeanProperty
 import scala.compiletime.uninitialized
 import scala.language.implicitConversions
@@ -49,6 +49,14 @@ class Monitoring extends RecordId {
   @BeanProperty
   @Column(name = "clinic_name", nullable = false)
   var clinicName: String = uninitialized
+
+  @BeanProperty
+  @Column(name = "clinic_ids", nullable = true)
+  var clinicIds: String = uninitialized
+
+  @BeanProperty
+  @Column(name = "clinic_names", nullable = true)
+  var clinicNames: String = uninitialized
 
   @BeanProperty
   @Column(name = "service_id", nullable = false)
@@ -117,6 +125,51 @@ class Monitoring extends RecordId {
   @BeanProperty
   @Column(name = "service_variant_id", nullable = true)
   var serviceVariantId: JLong = uninitialized
+
+  @BeanProperty
+  @Column(name = "excluded_weekdays", nullable = true)
+  var excludedWeekdays: String = uninitialized
+
+  @BeanProperty
+  @Column(name = "excluded_dates", nullable = true)
+  var excludedDates: String = uninitialized
+
+  def clinics: Seq[(Option[Long], String)] = {
+    val ids = Monitoring.parseLongs(clinicIds)
+    val names = Monitoring.parseStrings(clinicNames)
+    val parsed = ids.zipAll(names, -1L, "").map { case (id, name) =>
+      Option(id).filterNot(_ == -1L) -> name
+    }
+    if (parsed.nonEmpty) parsed else Seq(Option(clinicId).map(_.toLong) -> clinicName)
+  }
+
+  def clinicOptions: Seq[Option[Long]] = clinics.map(_._1) match {
+    case Nil => Seq(None)
+    case xs  => xs
+  }
+
+  def clinicFilter: Seq[Long] = clinicOptions.flatten.distinct
+
+  def singleClinicId: Option[Long] = {
+    val selected = clinicOptions.distinct
+    if (selected.size == 1) selected.head else None
+  }
+
+  def clinicDisplayName: String = clinics.map(_._2).filter(_.nonEmpty).distinct.mkString(", ")
+
+  def slotWeight: Int = {
+    val selected = clinicOptions
+    if (selected.exists(_.isEmpty)) 1 else selected.distinct.size.max(1)
+  }
+
+  def excludedWeekdaysSet: Set[DayOfWeek] =
+    Monitoring.parseInts(excludedWeekdays).flatMap(i => scala.util.Try(DayOfWeek.of(i)).toOption).toSet
+
+  def excludedDatesSet: Set[LocalDate] =
+    Monitoring.parseCommaStrings(excludedDates).flatMap(d => scala.util.Try(LocalDate.parse(d)).toOption).toSet
+
+  def isDateExcluded(date: LocalDate): Boolean =
+    excludedWeekdaysSet.contains(date.getDayOfWeek) || excludedDatesSet.contains(date)
 }
 
 object Monitoring {
@@ -131,6 +184,7 @@ object Monitoring {
     cityName: String,
     clinicId: Option[Long],
     clinicName: String,
+    clinics: Seq[(Option[Long], String)] = Seq.empty,
     serviceId: Long,
     serviceName: String,
     doctorId: Option[Long],
@@ -147,7 +201,9 @@ object Monitoring {
     isRehab: Boolean = false,
     referralId: Option[Long] = None,
     referralTypeId: Option[Int] = None,
-    serviceVariantId: Option[Long] = None
+    serviceVariantId: Option[Long] = None,
+    excludedWeekdays: Set[DayOfWeek] = Set.empty,
+    excludedDates: Set[LocalDate] = Set.empty
   ): Monitoring = {
     val monitoring = new Monitoring
     monitoring.userId = userId
@@ -160,6 +216,9 @@ object Monitoring {
     monitoring.cityName = cityName
     monitoring.clinicId = clinicId
     monitoring.clinicName = clinicName
+    val selectedClinics = if (clinics.nonEmpty) clinics else Seq(clinicId -> clinicName)
+    monitoring.clinicIds = selectedClinics.map(_._1.getOrElse(-1L)).mkString(",")
+    monitoring.clinicNames = selectedClinics.map(_._2).mkString("|")
     monitoring.serviceId = serviceId
     monitoring.serviceName = serviceName
     monitoring.doctorId = doctorId
@@ -177,6 +236,20 @@ object Monitoring {
     monitoring.referralId = referralId.map(Long.box).orNull
     monitoring.referralTypeId = referralTypeId.map(Int.box).orNull
     monitoring.serviceVariantId = serviceVariantId.map(Long.box).orNull
+    monitoring.excludedWeekdays = excludedWeekdays.toSeq.sortBy(_.getValue).map(_.getValue).mkString(",")
+    monitoring.excludedDates = excludedDates.toSeq.sortBy(_.toString).map(_.toString).mkString(",")
     monitoring
   }
+
+  private def parseLongs(value: String): Seq[Long] =
+    parseCommaStrings(value).flatMap(v => scala.util.Try(v.toLong).toOption)
+
+  private def parseInts(value: String): Seq[Int] =
+    parseCommaStrings(value).flatMap(v => scala.util.Try(v.toInt).toOption)
+
+  private def parseStrings(value: String): Seq[String] =
+    Option(value).toSeq.flatMap(_.split("\\|").map(_.trim).filter(_.nonEmpty))
+
+  private def parseCommaStrings(value: String): Seq[String] =
+    Option(value).toSeq.flatMap(_.split(",").map(_.trim).filter(_.nonEmpty))
 }

--- a/server/src/main/scala/com/lbs/server/repository/model/Monitoring.scala
+++ b/server/src/main/scala/com/lbs/server/repository/model/Monitoring.scala
@@ -1,5 +1,9 @@
 package com.lbs.server.repository.model
 
+import io.circe.*
+import io.circe.generic.semiauto.*
+import io.circe.parser.decode
+import io.circe.syntax.*
 import jakarta.persistence.{Access, AccessType, Column, Entity}
 
 import java.time.{DayOfWeek, LocalDate, LocalTime, ZonedDateTime}
@@ -57,6 +61,10 @@ class Monitoring extends RecordId {
   @BeanProperty
   @Column(name = "clinic_names", nullable = true)
   var clinicNames: String = uninitialized
+
+  @BeanProperty
+  @Column(name = "clinic_selection", nullable = true)
+  var clinicSelection: String = uninitialized
 
   @BeanProperty
   @Column(name = "service_id", nullable = false)
@@ -135,12 +143,16 @@ class Monitoring extends RecordId {
   var excludedDates: String = uninitialized
 
   def clinics: Seq[(Option[Long], String)] = {
-    val ids = Monitoring.parseLongs(clinicIds)
-    val names = Monitoring.parseStrings(clinicNames)
-    val parsed = ids.zipAll(names, -1L, "").map { case (id, name) =>
-      Option(id).filterNot(_ == -1L) -> name
+    val selected = Monitoring.parseClinicSelection(clinicSelection)
+    if (selected.nonEmpty) selected
+    else {
+      val ids = Monitoring.parseLongs(clinicIds)
+      val names = Monitoring.parseStrings(clinicNames)
+      val parsed = ids.zipAll(names, -1L, "").map { case (id, name) =>
+        Option(id).filterNot(_ == -1L) -> name
+      }
+      if (parsed.nonEmpty) parsed else Seq(Option(clinicId).map(_.toLong) -> clinicName)
     }
-    if (parsed.nonEmpty) parsed else Seq(Option(clinicId).map(_.toLong) -> clinicName)
   }
 
   def clinicOptions: Seq[Option[Long]] = clinics.map(_._1) match {
@@ -173,6 +185,10 @@ class Monitoring extends RecordId {
 }
 
 object Monitoring {
+  private case class ClinicSelection(id: Option[Long], name: String)
+
+  private given Codec[ClinicSelection] = deriveCodec
+
   def apply(
     userId: Long,
     username: String,
@@ -219,6 +235,7 @@ object Monitoring {
     val selectedClinics = if (clinics.nonEmpty) clinics else Seq(clinicId -> clinicName)
     monitoring.clinicIds = selectedClinics.map(_._1.getOrElse(-1L)).mkString(",")
     monitoring.clinicNames = selectedClinics.map(_._2).mkString("|")
+    monitoring.clinicSelection = Monitoring.formatClinicSelection(selectedClinics)
     monitoring.serviceId = serviceId
     monitoring.serviceName = serviceName
     monitoring.doctorId = doctorId
@@ -252,4 +269,16 @@ object Monitoring {
 
   private def parseCommaStrings(value: String): Seq[String] =
     Option(value).toSeq.flatMap(_.split(",").map(_.trim).filter(_.nonEmpty))
+
+  private def parseClinicSelection(value: String): Seq[(Option[Long], String)] =
+    Option(value)
+      .map(_.trim)
+      .filter(_.nonEmpty)
+      .flatMap(json => decode[Seq[ClinicSelection]](json).toOption)
+      .toSeq
+      .flatten
+      .map(clinic => clinic.id -> clinic.name)
+
+  private def formatClinicSelection(clinics: Seq[(Option[Long], String)]): String =
+    clinics.map { case (id, name) => ClinicSelection(id, name) }.asJson.noSpaces
 }

--- a/server/src/main/scala/com/lbs/server/service/ApiService.scala
+++ b/server/src/main/scala/com/lbs/server/service/ApiService.scala
@@ -113,17 +113,28 @@ class ApiService extends SessionSupport {
     doctorId: Option[Long] = None
   ): ThrowableOr[List[TermExt]] =
     withSession(accountId) { session =>
-       luxmedApi.rehabTermsIndex(session, cityId, serviceVariantId, referralId, referralTypeId,
-        fromDate, toDate, facilitiesIds = None, doctorId).map { response =>
-        response.termsForService.termsForDays
-          .flatMap(_.terms.map(term => TermExt(response.termsForService.additionalData, term)))
-          .filter { term =>
-            val time = term.term.dateTimeFrom.get.toLocalTime
-            (facilityId.isEmpty || facilityId.contains(term.term.clinicGroupId)) &&
-            (doctorId.isEmpty || doctorId.contains(term.term.doctor.id)) &&
-            (time == timeFrom || time == timeTo || (time.isAfter(timeFrom) && time.isBefore(timeTo)))
-          }
-      }
+      luxmedApi
+        .rehabTermsIndex(
+          session,
+          cityId,
+          serviceVariantId,
+          referralId,
+          referralTypeId,
+          fromDate,
+          toDate,
+          facilitiesIds = facilityId,
+          doctorId = doctorId
+        )
+        .map { response =>
+          response.termsForService.termsForDays
+            .flatMap(_.terms.map(term => TermExt(response.termsForService.additionalData, term)))
+            .filter { term =>
+              val time = term.term.dateTimeFrom.get.toLocalTime
+              (facilityId.isEmpty || facilityId.contains(term.term.clinicGroupId)) &&
+              (doctorId.isEmpty || doctorId.contains(term.term.doctor.id)) &&
+              (time == timeFrom || time == timeTo || (time.isAfter(timeFrom) && time.isBefore(timeTo)))
+            }
+        }
     }
 
   def reservationLockterm(

--- a/server/src/main/scala/com/lbs/server/service/DataService.scala
+++ b/server/src/main/scala/com/lbs/server/service/DataService.scala
@@ -167,21 +167,26 @@ class DataService {
   def storeAppointment(accountId: Long, bookingData: BookingData): Unit = {
     val time = ZonedDateTime.now()
     val cityId = bookingData.cityId
-    val clinicId = bookingData.clinicId
+    val clinicIds = bookingData.selectedClinics
     val serviceId = bookingData.serviceId
     val doctorId = bookingData.doctorId
 
     val city = CityHistory(accountId, cityId.id, cityId.name, time)
     dataRepository.saveEntity(city)
 
-    val clinicMaybe = clinicId.optionalId.map(id => ClinicHistory(accountId, id, clinicId.name, cityId.id, time))
-    clinicMaybe.foreach(dataRepository.saveEntity)
+    clinicIds.foreach { clinicId =>
+      clinicId.optionalId
+        .map(id => ClinicHistory(accountId, id, clinicId.name, cityId.id, time))
+        .foreach(dataRepository.saveEntity)
+    }
 
-    val service = ServiceHistory(accountId, serviceId.id, serviceId.name, cityId.id, clinicId.optionalId, time)
+    val clinicIdForHistory = if (clinicIds.size == 1) clinicIds.head.optionalId else None
+
+    val service = ServiceHistory(accountId, serviceId.id, serviceId.name, cityId.id, clinicIdForHistory, time)
     dataRepository.saveEntity(service)
 
     val doctorMaybe = doctorId.optionalId.map(id =>
-      DoctorHistory(accountId, id, doctorId.name, cityId.id, clinicId.optionalId, serviceId.id, time)
+      DoctorHistory(accountId, id, doctorId.name, cityId.id, clinicIdForHistory, serviceId.id, time)
     )
     doctorMaybe.foreach(dataRepository.saveEntity)
   }

--- a/server/src/main/scala/com/lbs/server/service/MonitoringService.scala
+++ b/server/src/main/scala/com/lbs/server/service/MonitoringService.scala
@@ -71,32 +71,10 @@ class MonitoringService extends StrictLogging {
     val dateFrom = optimizeDateFrom(monitoring.dateFrom.toLocalDateTime, monitoring.offset)
     val termsEither =
       if (monitoring.isRehab) {
-        apiService.getAvailableRehabTerms(
-          monitoring.accountId,
-          monitoring.cityId,
-          monitoring.serviceVariantId,
-          monitoring.referralId,
-          monitoring.referralTypeId,
-          dateFrom,
-          monitoring.dateTo.toLocalDateTime,
-          timeFrom = monitoring.timeFrom,
-          timeTo = monitoring.timeTo,
-          facilityId = Option(monitoring.clinicId).map(_.toLong),
-          doctorId = monitoring.doctorId
-        )
+        getAvailableRehabTerms(monitoring, dateFrom)
       } else {
-        apiService.getAvailableTerms(
-          monitoring.accountId,
-          monitoring.cityId,
-          monitoring.clinicId,
-          monitoring.serviceId,
-          monitoring.doctorId,
-          dateFrom,
-          monitoring.dateTo.toLocalDateTime,
-          timeFrom = monitoring.timeFrom,
-          timeTo = monitoring.timeTo
-        )
-      }
+        getAvailableTerms(monitoring, dateFrom)
+      }.map(filterExcludedDates(_, monitoring))
     termsEither match {
       case Right(terms) =>
         if (terms.nonEmpty) {
@@ -125,6 +103,50 @@ class MonitoringService extends StrictLogging {
     val nowWithOffset = LocalDateTime.now().plusHours(offset)
     if (date.isBefore(nowWithOffset)) nowWithOffset else date
   }
+
+  private def getAvailableTerms(monitoring: Monitoring, dateFrom: LocalDateTime): Either[Throwable, List[TermExt]] = {
+    val selectedClinicIds = monitoring.clinicFilter
+    apiService.getAvailableTerms(
+      monitoring.accountId,
+      monitoring.cityId,
+      monitoring.singleClinicId,
+      monitoring.serviceId,
+      monitoring.doctorId,
+      dateFrom,
+      monitoring.dateTo.toLocalDateTime,
+      timeFrom = monitoring.timeFrom,
+      timeTo = monitoring.timeTo
+    ).map(filterSelectedClinics(_, selectedClinicIds))
+      .map(_.sortBy(_.term.dateTimeFrom.get.toString))
+  }
+
+  private def getAvailableRehabTerms(
+    monitoring: Monitoring,
+    dateFrom: LocalDateTime
+  ): Either[Throwable, List[TermExt]] = {
+    val selectedClinicIds = monitoring.clinicFilter
+    apiService.getAvailableRehabTerms(
+      monitoring.accountId,
+      monitoring.cityId,
+      monitoring.serviceVariantId,
+      monitoring.referralId,
+      monitoring.referralTypeId,
+      dateFrom,
+      monitoring.dateTo.toLocalDateTime,
+      timeFrom = monitoring.timeFrom,
+      timeTo = monitoring.timeTo,
+      facilityId = monitoring.singleClinicId,
+      doctorId = monitoring.doctorId
+    ).map(filterSelectedClinics(_, selectedClinicIds))
+      .map(_.sortBy(_.term.dateTimeFrom.get.toString))
+  }
+
+  private def filterSelectedClinics(terms: List[TermExt], clinicIds: Seq[Long]): List[TermExt] =
+    if (clinicIds.size <= 1) terms
+    else terms.filter(term => clinicIds.contains(term.term.clinicGroupId))
+
+  private def filterExcludedDates(terms: List[TermExt], monitoring: Monitoring): List[TermExt] =
+    terms.filterNot(term => monitoring.isDateExcluded(term.term.dateTimeFrom.get.toLocalDate))
 
   private def initializeMonitorings(allMonitorings: Seq[Monitoring]): Unit = {
     allMonitorings.foreach { monitoring =>
@@ -260,8 +282,8 @@ class MonitoringService extends StrictLogging {
   }
 
   def createMonitoring(monitoring: Monitoring): Monitoring = {
-    val userMonitoringsCount = dataService.getActiveMonitoringsCount(monitoring.accountId)
-    require(userMonitoringsCount + 1 <= 10, lang(monitoring.userId).maximumMonitoringsLimitExceeded)
+    val activeMonitoringsWeight = dataService.getActiveMonitorings(monitoring.accountId).map(_.slotWeight).sum
+    require(activeMonitoringsWeight + monitoring.slotWeight <= 10, lang(monitoring.userId).maximumMonitoringsLimitExceeded)
     dataService.saveMonitoring(monitoring)
   }
 
@@ -281,17 +303,10 @@ class MonitoringService extends StrictLogging {
     val monitoringMaybe = dataService.findMonitoring(accountId, monitoringId)
     monitoringMaybe match {
       case Some(monitoring) =>
-        val termsEither = apiService.getAvailableTerms(
-          monitoring.accountId,
-          monitoring.cityId,
-          monitoring.clinicId,
-          monitoring.serviceId,
-          monitoring.doctorId,
-          monitoring.dateFrom.toLocalDateTime,
-          monitoring.dateTo.toLocalDateTime,
-          timeFrom = monitoring.timeFrom,
-          timeTo = monitoring.timeTo
-        )
+        val termsEither = (
+          if (monitoring.isRehab) getAvailableRehabTerms(monitoring, monitoring.dateFrom.toLocalDateTime)
+          else getAvailableTerms(monitoring, monitoring.dateFrom.toLocalDateTime)
+        ).map(filterExcludedDates(_, monitoring))
         termsEither match {
           case Right(terms) =>
             val termMaybe = terms.find(term =>

--- a/server/src/main/scala/com/lbs/server/service/MonitoringService.scala
+++ b/server/src/main/scala/com/lbs/server/service/MonitoringService.scala
@@ -117,7 +117,7 @@ class MonitoringService extends StrictLogging {
       timeFrom = monitoring.timeFrom,
       timeTo = monitoring.timeTo
     ).map(filterSelectedClinics(_, selectedClinicIds))
-      .map(_.sortBy(_.term.dateTimeFrom.get.toString))
+      .map(_.sortBy(_.term.dateTimeFrom.get))
   }
 
   private def getAvailableRehabTerms(
@@ -138,7 +138,7 @@ class MonitoringService extends StrictLogging {
       facilityId = monitoring.singleClinicId,
       doctorId = monitoring.doctorId
     ).map(filterSelectedClinics(_, selectedClinicIds))
-      .map(_.sortBy(_.term.dateTimeFrom.get.toString))
+      .map(_.sortBy(_.term.dateTimeFrom.get))
   }
 
   private def filterSelectedClinics(terms: List[TermExt], clinicIds: Seq[Long]): List[TermExt] =

--- a/server/src/main/scala/com/lbs/server/util/package.scala
+++ b/server/src/main/scala/com/lbs/server/util/package.scala
@@ -19,6 +19,7 @@ import scala.util.Try
     implicit val BookingDataToMonitoringConverter: ObjectConverter[(UserId, BookingData), Monitoring] =
       (data: (UserId, BookingData)) => {
         val (userId, bookingData) = data
+        val primaryClinic = bookingData.selectedClinics.headOption.getOrElse(IdName(-1L, "Any"))
         Monitoring(
           userId = userId.userId,
           username = userId.username,
@@ -28,8 +29,9 @@ import scala.util.Try
           payerId = bookingData.payerId,
           cityId = bookingData.cityId.id,
           cityName = bookingData.cityId.name,
-          clinicId = bookingData.clinicId.optionalId,
-          clinicName = bookingData.clinicId.name,
+          clinicId = primaryClinic.optionalId,
+          clinicName = primaryClinic.name,
+          clinics = bookingData.selectedClinics.map(c => c.optionalId -> c.name),
           serviceId = bookingData.serviceId.id,
           serviceName = bookingData.serviceId.name,
           doctorId = bookingData.doctorId.optionalId,
@@ -40,7 +42,9 @@ import scala.util.Try
           timeTo = bookingData.timeTo,
           autobook = bookingData.autobook,
           rebookIfExists = bookingData.rebookIfExists,
-          offset = bookingData.offset
+          offset = bookingData.offset,
+          excludedWeekdays = bookingData.excludedWeekdays,
+          excludedDates = bookingData.excludedDates
         )
       }
 
@@ -142,6 +146,7 @@ import scala.util.Try
     implicit val RehabBookingDataToMonitoringConverter: ObjectConverter[(UserId, RehabBookingData), Monitoring] =
       (data: (UserId, RehabBookingData)) => {
         val (userId, d) = data
+        val primaryFacility = d.selectedFacilities.headOption.getOrElse(IdName(-1L, "Any"))
         Monitoring(
           userId = userId.userId,
           username = userId.username,
@@ -151,8 +156,9 @@ import scala.util.Try
           payerId = 0L,
           cityId = d.cityId.id,
           cityName = d.cityId.name,
-          clinicId = Option(d.facilityId).flatMap(_.optionalId),
-          clinicName = Option(d.facilityId).map(_.name).getOrElse("Any"),
+          clinicId = primaryFacility.optionalId,
+          clinicName = primaryFacility.name,
+          clinics = d.selectedFacilities.map(f => f.optionalId -> f.name),
           serviceId = d.serviceVariantId,
           serviceName = d.serviceVariantName,
           doctorId = Option(d.physiotherapistId).flatMap(_.optionalId),
@@ -167,7 +173,9 @@ import scala.util.Try
           isRehab = true,
           referralId = Some(d.referralId),
           referralTypeId = Some(d.referralTypeId),
-          serviceVariantId = Some(d.serviceVariantId)
+          serviceVariantId = Some(d.serviceVariantId),
+          excludedWeekdays = d.excludedWeekdays,
+          excludedDates = d.excludedDates
         )
       }
   }
@@ -243,4 +251,3 @@ import scala.util.Try
       LocalTime.parse(hourMinuteStr, TimeFormat)
     }
   }
-

--- a/server/src/test/scala/com/lbs/server/conversation/BookSpec.scala
+++ b/server/src/test/scala/com/lbs/server/conversation/BookSpec.scala
@@ -2,18 +2,20 @@ package com.lbs.server.conversation
 
 import com.lbs.api.json.model.*
 import com.lbs.bot.Bot
-import com.lbs.bot.model.{Command, Message, MessageSource, TelegramMessageSourceSystem}
+import com.lbs.bot.model.{Command, InlineKeyboard, Message, MessageSource, TelegramMessageSourceSystem}
+import com.lbs.server.conversation.DatePicker.DateRange
 import com.lbs.server.conversation.Book.Tags
 import com.lbs.server.conversation.Login.UserId
 import com.lbs.server.conversation.Pager.NoItemsFound
 import com.lbs.server.conversation.base.ConversationTestProbe
 import com.lbs.server.lang.{En, Localization}
-import com.lbs.server.repository.model.Settings
+import com.lbs.server.repository.model.{Monitoring, Settings}
 import com.lbs.server.service.{ApiService, DataService, MonitoringService}
+import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.*
 import org.mockito.Mockito.*
 
-import java.time.{LocalDateTime, LocalTime}
+import java.time.{DayOfWeek, LocalDate, LocalDateTime, LocalTime}
 
 class BookSpec extends AkkaTestKit {
 
@@ -53,10 +55,21 @@ class BookSpec extends AkkaTestKit {
   private def callbackCmd(tag: String) =
     Command(source, Message("1", Some(tag)), Some(tag))
 
-  private def selectStaticData(book: Book): Unit = {
+  private def awaitClinicContinuationPrompt(bot: Bot, selectedClinic: String): Unit =
+    awaitAssert(
+      verify(bot, atLeastOnce()).sendMessage(
+        any[MessageSource](),
+        contains(selectedClinic),
+        any[Option[InlineKeyboard]]()
+      )
+    )
+
+  private def selectStaticData(book: Book, bot: Bot): Unit = {
     book ! IdName(1L, "Wroclaw")
     book ! IdName(100L, "GP Consultation")
     book ! IdName(10L, "Swobodna Clinic")
+    awaitClinicContinuationPrompt(bot, "Swobodna Clinic")
+    book ! callbackCmd(Tags.Continue)
     book ! IdName(50L, "Dr Smith")
   }
 
@@ -132,10 +145,11 @@ class BookSpec extends AkkaTestKit {
         val pp = ConversationTestProbe[Pager[TermExt]]()
         val apiService  = makeApiService
         val dataService = makeDataService
+        val bot         = makeBot
         stubBookingFlow(apiService, dataService)
-        val book = makeBook(apiService = apiService, dataService = dataService)(dp, tp, sp, pp)
+        val book = makeBook(bot = bot, apiService = apiService, dataService = dataService)(dp, tp, sp, pp)
         book.start()
-        selectStaticData(book)
+        selectStaticData(book, bot)
         selectDates(book)
         book ! callbackCmd(Tags.FindTerms)
         book ! sampleTerm
@@ -149,10 +163,11 @@ class BookSpec extends AkkaTestKit {
         val sp = ConversationTestProbe[StaticData]()
         val pp = ConversationTestProbe[Pager[TermExt]]()
         val dataService = makeDataService
+        val bot         = makeBot
         doNothing().when(dataService).storeAppointment(any(), any())
-        val book = makeBook(dataService = dataService)(dp, tp, sp, pp)
+        val book = makeBook(bot = bot, dataService = dataService)(dp, tp, sp, pp)
         book.start()
-        selectStaticData(book)
+        selectStaticData(book, bot)
         selectDates(book)
         book ! callbackCmd(Tags.ModifyDate)
         val base = LocalDateTime.now().plusDays(3)
@@ -163,6 +178,57 @@ class BookSpec extends AkkaTestKit {
         succeed
       }
 
+      "accept a date range from date picker and skip requestDateTo" in {
+        val dp = ConversationTestProbe[DatePicker]()
+        val tp = ConversationTestProbe[TimePicker]()
+        val sp = ConversationTestProbe[StaticData]()
+        val pp = ConversationTestProbe[Pager[TermExt]]()
+        val apiService  = makeApiService
+        val dataService = makeDataService
+        val bot         = makeBot
+        stubBookingFlow(apiService, dataService)
+        val book = makeBook(bot = bot, apiService = apiService, dataService = dataService)(dp, tp, sp, pp)
+        val from = LocalDateTime.now().plusDays(1)
+        val to = from.plusDays(7)
+        book.start()
+        sp.expectMsgType[StaticData.StaticDataConfig]
+        book ! IdName(1L, "Wroclaw")
+        sp.expectMsgType[StaticData.StaticDataConfig]
+        book ! IdName(100L, "GP Consultation")
+        sp.expectMsgType[StaticData.StaticDataConfig]
+        book ! IdName(10L, "Swobodna Clinic")
+        awaitClinicContinuationPrompt(bot, "Swobodna Clinic")
+        book ! callbackCmd(Tags.Continue)
+        sp.expectMsgType[StaticData.StaticDataConfig]
+        book ! IdName(50L, "Dr Smith")
+        dp.expectMsg(DatePicker.DateFromMode)
+        dp.expectMsgType[LocalDateTime]
+        book ! DateRange(from, to)
+        tp.fishForMessage() {
+          case TimePicker.TimeFromMode => true
+          case _                       => false
+        }
+        tp.fishForMessage() {
+          case _: LocalTime => true
+          case _            => false
+        }
+        book ! LocalTime.of(8, 0)
+        tp.fishForMessage() {
+          case TimePicker.TimeToMode => true
+          case _                     => false
+        }
+        tp.fishForMessage() {
+          case _: LocalTime => true
+          case _            => false
+        }
+        book ! LocalTime.of(20, 0)
+        awaitAssert(verify(dataService, atLeastOnce()).storeAppointment(any(), any()))
+        book ! callbackCmd(Tags.FindTerms)
+        awaitAssert(verify(apiService, atLeastOnce()).getAvailableTerms(
+          anyLong(), anyLong(), any(), anyLong(), any(), any(), any(), any(), any(), anyLong()
+        ))
+      }
+
       "delete temporary reservation when Cancel is clicked" in {
         val dp = ConversationTestProbe[DatePicker]()
         val tp = ConversationTestProbe[TimePicker]()
@@ -170,12 +236,13 @@ class BookSpec extends AkkaTestKit {
         val pp = ConversationTestProbe[Pager[TermExt]]()
         val apiService  = makeApiService
         val dataService = makeDataService
+        val bot         = makeBot
         stubBookingFlow(apiService, dataService)
         when(apiService.deleteTemporaryReservation(anyLong(), any(), anyLong()))
           .thenReturn(Right(()))
-        val book = makeBook(apiService = apiService, dataService = dataService)(dp, tp, sp, pp)
+        val book = makeBook(bot = bot, apiService = apiService, dataService = dataService)(dp, tp, sp, pp)
         book.start()
-        selectStaticData(book)
+        selectStaticData(book, bot)
         selectDates(book)
         book ! callbackCmd(Tags.FindTerms)
         book ! sampleTerm
@@ -194,17 +261,19 @@ class BookSpec extends AkkaTestKit {
         val apiService        = makeApiService
         val dataService       = makeDataService
         val monitoringService = makeMonitoringService
+        val bot               = makeBot
         doNothing().when(dataService).storeAppointment(any(), any())
         stubGetTerms(apiService, Right(Nil))
         when(dataService.findSettings(anyLong())).thenReturn(None)
-        val book = makeBook(apiService = apiService, dataService = dataService,
+        val book = makeBook(bot = bot, apiService = apiService, dataService = dataService,
                             monitoringService = monitoringService)(dp, tp, sp, pp)
         book.start()
-        selectStaticData(book)
+        selectStaticData(book, bot)
         selectDates(book)
         book ! callbackCmd(Tags.FindTerms)
         book ! NoItemsFound
         book ! callbackCmd(Tags.CreateMonitoring)
+        book ! callbackCmd(Tags.No) // no exclusions
         book ! callbackCmd(Tags.BookManually)
         awaitAssert(verify(monitoringService).createMonitoring(any()))
       }
@@ -216,12 +285,13 @@ class BookSpec extends AkkaTestKit {
         val pp = ConversationTestProbe[Pager[TermExt]]()
         val apiService  = makeApiService
         val dataService = makeDataService
+        val bot         = makeBot
         doNothing().when(dataService).storeAppointment(any(), any())
         stubGetTerms(apiService, Right(Nil))
         when(dataService.findSettings(anyLong())).thenReturn(None)
-        val book = makeBook(apiService = apiService, dataService = dataService)(dp, tp, sp, pp)
+        val book = makeBook(bot = bot, apiService = apiService, dataService = dataService)(dp, tp, sp, pp)
         book.start()
-        selectStaticData(book)
+        selectStaticData(book, bot)
         selectDates(book)
         book ! callbackCmd(Tags.FindTerms)
         book ! NoItemsFound
@@ -244,13 +314,14 @@ class BookSpec extends AkkaTestKit {
         val pp = ConversationTestProbe[Pager[TermExt]]()
         val apiService  = makeApiService
         val dataService = makeDataService
+        val bot         = makeBot
         stubBookingFlow(apiService, dataService,
           lockResponse = sampleLockResponse(changeTermAvailable = true))
         when(apiService.reservationChangeTerm(anyLong(), any(), any()))
           .thenReturn(Right(sampleConfirmResponse))
-        val book = makeBook(apiService = apiService, dataService = dataService)(dp, tp, sp, pp)
+        val book = makeBook(bot = bot, apiService = apiService, dataService = dataService)(dp, tp, sp, pp)
         book.start()
-        selectStaticData(book)
+        selectStaticData(book, bot)
         selectDates(book)
         book ! callbackCmd(Tags.FindTerms)
         book ! sampleTerm
@@ -265,11 +336,12 @@ class BookSpec extends AkkaTestKit {
         val pp = ConversationTestProbe[Pager[TermExt]]()
         val apiService  = makeApiService
         val dataService = makeDataService
+        val bot         = makeBot
         stubBookingFlow(apiService, dataService,
           lockResponse = sampleLockResponse(changeTermAvailable = true))
-        val book = makeBook(apiService = apiService, dataService = dataService)(dp, tp, sp, pp)
+        val book = makeBook(bot = bot, apiService = apiService, dataService = dataService)(dp, tp, sp, pp)
         book.start()
-        selectStaticData(book)
+        selectStaticData(book, bot)
         selectDates(book)
         book ! callbackCmd(Tags.FindTerms)
         book ! sampleTerm
@@ -291,19 +363,21 @@ class BookSpec extends AkkaTestKit {
         val apiService        = makeApiService
         val dataService       = makeDataService
         val monitoringService = makeMonitoringService
+        val bot               = makeBot
         doNothing().when(dataService).storeAppointment(any(), any())
         stubGetTerms(apiService, Right(Nil))
         when(dataService.findSettings(userId.userId))
           .thenReturn(Some(Settings(userId.userId, 0, 0, alwaysAskOffset = true)))
-        val book = makeBook(apiService = apiService, dataService = dataService,
+        val book = makeBook(bot = bot, apiService = apiService, dataService = dataService,
                             monitoringService = monitoringService)(dp, tp, sp, pp)
         book.start()
-        selectStaticData(book)
+        selectStaticData(book, bot)
         selectDates(book)
         book ! callbackCmd(Tags.FindTerms)
         book ! NoItemsFound
         book ! callbackCmd(Tags.CreateMonitoring)
         book ! Command(source, Message("1", Some("30")), None) // enter offset
+        book ! callbackCmd(Tags.No)                            // no exclusions
         book ! callbackCmd(Tags.BookByApplication)            // autobook = true
         book ! callbackCmd(Tags.Yes)                          // rebookIfExists = true
         awaitAssert(verify(monitoringService).createMonitoring(any()))
@@ -317,21 +391,65 @@ class BookSpec extends AkkaTestKit {
         val apiService        = makeApiService
         val dataService       = makeDataService
         val monitoringService = makeMonitoringService
+        val bot               = makeBot
         doNothing().when(dataService).storeAppointment(any(), any())
         stubGetTerms(apiService, Right(Nil))
         when(dataService.findSettings(userId.userId))
           .thenReturn(Some(Settings(userId.userId, 0, 0, alwaysAskOffset = true)))
-        val book = makeBook(apiService = apiService, dataService = dataService,
+        val book = makeBook(bot = bot, apiService = apiService, dataService = dataService,
                             monitoringService = monitoringService)(dp, tp, sp, pp)
         book.start()
-        selectStaticData(book)
+        selectStaticData(book, bot)
         selectDates(book)
         book ! callbackCmd(Tags.FindTerms)
         book ! NoItemsFound
         book ! callbackCmd(Tags.CreateMonitoring)
         book ! callbackCmd(Tags.No)           // skip offset
+        book ! callbackCmd(Tags.No)           // no exclusions
         book ! callbackCmd(Tags.BookManually) // manual booking
         awaitAssert(verify(monitoringService).createMonitoring(any()))
+      }
+
+      "create one monitoring with multiple clinics and exclusions" in {
+        val dp = ConversationTestProbe[DatePicker]()
+        val tp = ConversationTestProbe[TimePicker]()
+        val sp = ConversationTestProbe[StaticData]()
+        val pp = ConversationTestProbe[Pager[TermExt]]()
+        val apiService        = makeApiService
+        val dataService       = makeDataService
+        val monitoringService = makeMonitoringService
+        val bot               = makeBot
+        doNothing().when(dataService).storeAppointment(any(), any())
+        stubGetTerms(apiService, Right(Nil))
+        when(dataService.findSettings(anyLong())).thenReturn(None)
+        val book = makeBook(bot = bot, apiService = apiService, dataService = dataService,
+                            monitoringService = monitoringService)(dp, tp, sp, pp)
+        book.start()
+        book ! IdName(1L, "Wroclaw")
+        book ! IdName(100L, "GP Consultation")
+        book ! IdName(10L, "Swobodna Clinic")
+        awaitClinicContinuationPrompt(bot, "Swobodna Clinic")
+        book ! callbackCmd(Tags.AddAnotherClinic)
+        book ! IdName(11L, "Legnicka Clinic")
+        awaitClinicContinuationPrompt(bot, "Legnicka Clinic")
+        book ! callbackCmd(Tags.Continue)
+        book ! IdName(50L, "Dr Smith")
+        selectDates(book)
+        book ! callbackCmd(Tags.FindTerms)
+        book ! NoItemsFound
+        book ! callbackCmd(Tags.CreateMonitoring)
+        book ! callbackCmd(Tags.Yes) // add exclusions
+        book ! callbackCmd(Tags.WeekdayPrefix + DayOfWeek.TUESDAY.getValue)
+        book ! callbackCmd(Tags.Done)
+        book ! Command(source, Message("1", Some("2026-06-10")), None)
+        book ! callbackCmd(Tags.BookManually)
+
+        val captor = ArgumentCaptor.forClass(classOf[Monitoring])
+        awaitAssert(verify(monitoringService).createMonitoring(captor.capture()))
+        val monitoring = captor.getValue
+        assert(monitoring.clinicOptions == Seq(Some(10L), Some(11L)))
+        assert(monitoring.excludedWeekdaysSet == Set(DayOfWeek.TUESDAY))
+        assert(monitoring.excludedDatesSet == Set(LocalDate.parse("2026-06-10")))
       }
     }
   }

--- a/server/src/test/scala/com/lbs/server/conversation/BookSpec.scala
+++ b/server/src/test/scala/com/lbs/server/conversation/BookSpec.scala
@@ -77,6 +77,8 @@ class BookSpec extends AkkaTestKit {
     val now = LocalDateTime.now()
     book ! now
     book ! now.plusDays(7)
+    book ! callbackCmd(Tags.Done)
+    book ! callbackCmd(Tags.No)
     book ! LocalTime.of(8, 0)
     book ! LocalTime.of(20, 0)
   }
@@ -173,6 +175,8 @@ class BookSpec extends AkkaTestKit {
         val base = LocalDateTime.now().plusDays(3)
         book ! base
         book ! base.plusDays(7)
+        book ! callbackCmd(Tags.Done)
+        book ! callbackCmd(Tags.No)
         book ! LocalTime.of(9, 0)
         book ! LocalTime.of(18, 0)
         succeed
@@ -204,6 +208,8 @@ class BookSpec extends AkkaTestKit {
         dp.expectMsg(DatePicker.DateFromMode)
         dp.expectMsgType[LocalDateTime]
         book ! DateRange(from, to)
+        book ! callbackCmd(Tags.Done)
+        book ! callbackCmd(Tags.No)
         tp.fishForMessage() {
           case TimePicker.TimeFromMode => true
           case _                       => false
@@ -273,7 +279,6 @@ class BookSpec extends AkkaTestKit {
         book ! callbackCmd(Tags.FindTerms)
         book ! NoItemsFound
         book ! callbackCmd(Tags.CreateMonitoring)
-        book ! callbackCmd(Tags.No) // no exclusions
         book ! callbackCmd(Tags.BookManually)
         awaitAssert(verify(monitoringService).createMonitoring(any()))
       }
@@ -299,6 +304,8 @@ class BookSpec extends AkkaTestKit {
         val base = LocalDateTime.now().plusDays(2)
         book ! base
         book ! base.plusDays(9)
+        book ! callbackCmd(Tags.Done)
+        book ! callbackCmd(Tags.No)
         book ! LocalTime.of(7, 0)
         book ! LocalTime.of(21, 0)
         succeed
@@ -377,7 +384,6 @@ class BookSpec extends AkkaTestKit {
         book ! NoItemsFound
         book ! callbackCmd(Tags.CreateMonitoring)
         book ! Command(source, Message("1", Some("30")), None) // enter offset
-        book ! callbackCmd(Tags.No)                            // no exclusions
         book ! callbackCmd(Tags.BookByApplication)            // autobook = true
         book ! callbackCmd(Tags.Yes)                          // rebookIfExists = true
         awaitAssert(verify(monitoringService).createMonitoring(any()))
@@ -405,7 +411,6 @@ class BookSpec extends AkkaTestKit {
         book ! NoItemsFound
         book ! callbackCmd(Tags.CreateMonitoring)
         book ! callbackCmd(Tags.No)           // skip offset
-        book ! callbackCmd(Tags.No)           // no exclusions
         book ! callbackCmd(Tags.BookManually) // manual booking
         awaitAssert(verify(monitoringService).createMonitoring(any()))
       }
@@ -434,14 +439,17 @@ class BookSpec extends AkkaTestKit {
         awaitClinicContinuationPrompt(bot, "Legnicka Clinic")
         book ! callbackCmd(Tags.Continue)
         book ! IdName(50L, "Dr Smith")
-        selectDates(book)
-        book ! callbackCmd(Tags.FindTerms)
-        book ! NoItemsFound
-        book ! callbackCmd(Tags.CreateMonitoring)
-        book ! callbackCmd(Tags.Yes) // add exclusions
+        val now = LocalDateTime.now()
+        book ! now
+        book ! now.plusDays(7)
         book ! callbackCmd(Tags.WeekdayPrefix + DayOfWeek.TUESDAY.getValue)
         book ! callbackCmd(Tags.Done)
         book ! Command(source, Message("1", Some("2026-06-10")), None)
+        book ! LocalTime.of(8, 0)
+        book ! LocalTime.of(20, 0)
+        book ! callbackCmd(Tags.FindTerms)
+        book ! NoItemsFound
+        book ! callbackCmd(Tags.CreateMonitoring)
         book ! callbackCmd(Tags.BookManually)
 
         val captor = ArgumentCaptor.forClass(classOf[Monitoring])

--- a/server/src/test/scala/com/lbs/server/repository/model/MonitoringSpec.scala
+++ b/server/src/test/scala/com/lbs/server/repository/model/MonitoringSpec.scala
@@ -1,0 +1,54 @@
+package com.lbs.server.repository.model
+
+import org.scalatest.wordspec.AnyWordSpec
+
+class MonitoringSpec extends AnyWordSpec {
+
+  "Monitoring clinic selection" should {
+
+    "read clinic selection from JSON before legacy fields" in {
+      val monitoring = new Monitoring
+      monitoring.clinicSelection = """[{"id":2764,"name":"A | B"},{"id":null,"name":"Any"}]"""
+      monitoring.clinicIds = "1"
+      monitoring.clinicNames = "Legacy"
+
+      assert(monitoring.clinics == Seq(Some(2764L) -> "A | B", None -> "Any"))
+    }
+
+    "fall back to legacy clinic ids and names" in {
+      val monitoring = new Monitoring
+      monitoring.clinicIds = "2764,2769"
+      monitoring.clinicNames = "Modlinska|Mysliborska"
+
+      assert(monitoring.clinics == Seq(Some(2764L) -> "Modlinska", Some(2769L) -> "Mysliborska"))
+    }
+
+    "write JSON clinic selection for new monitorings" in {
+      val monitoring = Monitoring(
+        userId = 1L,
+        username = "user",
+        accountId = 2L,
+        chatId = "3",
+        sourceSystemId = 4L,
+        payerId = 5L,
+        cityId = 6L,
+        cityName = "Warszawa",
+        clinicId = None,
+        clinicName = "Any",
+        clinics = Seq(None -> "Any"),
+        serviceId = 7L,
+        serviceName = "Consultation",
+        doctorId = None,
+        doctorName = "Any",
+        dateFrom = java.time.ZonedDateTime.now(),
+        dateTo = java.time.ZonedDateTime.now().plusDays(1),
+        timeFrom = java.time.LocalTime.of(7, 0),
+        timeTo = java.time.LocalTime.of(21, 0),
+        offset = 0
+      )
+
+      assert(monitoring.clinicSelection == """[{"id":null,"name":"Any"}]""")
+      assert(monitoring.clinics == Seq(None -> "Any"))
+    }
+  }
+}


### PR DESCRIPTION
I love what you've done with the bot! I set it up locally and made a few tweaks of my own, so I thought I'd share them here. These are mostly UX improvements to the booking flow:

- Allow a single monitor to watch multiple selected clinics and facilities.
- Add optional weekday and exact-date exclusions for monitoring.
- Align the rehab booking flow with the regular booking process.
- Add quick and manually typed date ranges to the date picker.
- Reduce API calls by fetching all facilities once and filtering locally (for example, when monitoring 3 facilities instead of 1). I'm not sure how close this gets to Luxmed API rate limits, so please let me know if this feels too heavy. I haven't noticed any issues on my local instance.

## How it looks

### Multiple clinics
<img width="450" alt="Multiple clinics" src="https://github.com/user-attachments/assets/6bc2904b-43db-4ce1-872f-13e5ec89587c" />

### Excluded days
<img width="450" alt="Excluded days" src="https://github.com/user-attachments/assets/4151dda4-6dfe-4626-b859-0a37a4aec87a" />

### Quick date ranges
<img width="450" alt="Quick date ranges" src="https://github.com/user-attachments/assets/82a9adf3-3baa-4e3c-9b00-0b18163a0c92" />